### PR TITLE
Add x-hub-signature Header Verification to HTTP Requests

### DIFF
--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -49,6 +49,27 @@ configure:
 
     % heroku config:add HEROKU_URL=http://rosemary-britches-123.herokuapp.com
 
+If your hubot will be listening for http connections and you would like to
+verify [x-hub-signature headers](http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html#authednotify)
+you can also set this environment variable:
+
+    % heroku config:add HUB_SECRET=<YOUR_SECRET_HERE>
+
+Setting this will cause any requests with the `x-hub-signature` header set to
+fail unless the signature is validated. Requests not containing this header
+will always succeed.
+
+Scripts can ensure that requests that have been validated by checking
+`req.hubVerified`. However, for convenience, if you have a particular script
+that you want to require a valid `x-hub-signature` for, you can so do like this:
+
+```coffeescript
+module.exports = (robot) ->
+  robot.router.post "/some/url",
+                    robot.requireHubSignature,
+                    fn
+```
+
 At this point, you are ready to deploy and start chatting. With Heroku, that's a
 git push away:
 

--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -65,7 +65,7 @@ before:
 
     % git commit -am "Awesome scripts OMG"
     % git push heroku master
-    
+
 Some scripts needs Redis to work, Heroku offers an addon called [RedisToGo](https://addons.heroku.com/RedisToGo), which has a free nano plan. To use it:
 
     % heroku addons:add redistogo:nano

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -390,7 +390,7 @@ module.exports = (robot) ->
 
 ## HTTP Listener
 
-Hubot includes support for the [express](http://expressjs.com/guide.html) web framework to server up HTTP requests. It listens on the port specified by the `PORT` environment variable, and defaults to 8080. An instance of an express application is available at `robot.router`. It can be protected with username and password by specifying `EXPRESS_USER` and `EPXRESS_PASSWORD`. It can automatically server static files by setting `EXPRESS_STATIC`.
+Hubot includes support for the [express](http://expressjs.com/guide.html) web framework to server up HTTP requests. It listens on the port specified by the `PORT` environment variable, and defaults to 8080. An instance of an express application is available at `robot.router`. It can be protected with username and password by specifying `EXPRESS_USER` and `EPXRESS_PASSWORD`. It can automatically serve static files by setting `EXPRESS_STATIC`.
 
 The most common use of this is for providing HTTP end points for services with webhooks to push to, and have those show up in chat.
 
@@ -403,6 +403,20 @@ module.exports = (robot) ->
     secret = data.secret
 
     robot.messageRoom room, "I have a secret: #{secret}"
+```
+
+### HTTP Request verification
+If your hubot will be listening for http connections and you would like to verify [x-hub-signature headers](http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html#authednotify) you can set the `HUB_SECRET` environment variable.
+
+Setting this will cause any requests with the `x-hub-signature` header set to fail unless the signature is validated. Requests not containing this header will always succeed.
+
+Scripts can ensure that requests that have been validated by checking `req.hubVerified`. However, for convenience, if you have a particular script that you want to require a valid `x-hub-signature` for, you can so do like this:
+
+```coffeescript
+module.exports = (robot) ->
+  robot.router.post "/some/url",
+                    robot.requireHubSignature,
+                    fn
 ```
 
 ## Events

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "optparse":           "1.0.4",
     "scoped-http-client": "0.9.8",
     "log":                "1.4.0",
-    "express":            "3.3.4"
+    "express":            "3.4.4"
   },
 
   "engines": {

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -261,7 +261,6 @@ class Robot
 
   requireHubSignature: (req, res, next) ->
     return next new Error "Invalid Hub Signature" unless req.hubVerified
-    @logger.debug "x-hub-signature verified"
     next()
 
   # Setup the Express server's defaults.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -259,6 +259,11 @@ class Robot
       @logger.error "Error loading scripts from npm package - #{err.stack}"
       process.exit(1)
 
+  requireHubSignature: (req, res, next) ->
+    return next new Error "Invalid Hub Signature" unless req.hubVerified
+    @logger.debug "x-hub-signature verified"
+    next()
+
   # Setup the Express server's defaults.
   #
   # Returns nothing.
@@ -267,12 +272,40 @@ class Robot
     pass    = process.env.EXPRESS_PASSWORD
     stat    = process.env.EXPRESS_STATIC
 
+    verifyHub = (req, res, buffer) ->
+      secret    = process.env.HUB_SECRET
+      signature = req.header "x-hub-signature"
+
+      ## the request could not be verified, but it's not an error
+      ## req.hubVerified will still be `undefined`
+      return unless secret and signature
+
+      signature = signature.split '='
+      algo      = signature[0]
+      signature = signature[1]
+
+      ## connect.json.verify will catch any thrown errors and cause the request
+      ## to be rejected with 403 Forbidden
+
+      throw new Error "Invalid Hub Signature" unless algo is "sha1"
+
+      hmac = require("crypto")
+        .createHmac(algo, secret)
+        .update(buffer)
+        .digest("hex")
+
+      throw new Error "Invalid Hub Signature" unless hmac is signature
+
+      req.hubVerified = true
+
     express = require 'express'
 
     app = express()
+
     app.use express.basicAuth user, pass if user and pass
     app.use express.query()
-    app.use express.bodyParser()
+    app.use express.json       verify: verifyHub
+    app.use express.urlencoded verify: verifyHub
     app.use express.static stat if stat
 
     try


### PR DESCRIPTION
If an incoming HTTP request has the `x-hub-signature` header set and the `HUB_SECRET` environment variable is set, verify that the signature is valid.

An invalid signature will not be processed as an error will be thrown from the middleware.

If either the `HUB_SECRET` environment variable isn't set or the `x-hub-signature` header wasn't present in the request, then verification will be bypassed. However, `req.hubVerified` will be undefined.

Any script that wants to ensure only verified requests will be processed can do so like this:

``` coffeescript
module.exports = (robot) ->
  robot.router.post "/some/url",
                    robot.requireHubSignature,
                    fn
```

The version of express must also be updated so that it includes the latest connect middleware that provides the verification capability.
