### PR TITLE
Clean up events during shutdown

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -63,8 +63,7 @@ class Robot
 
     @on 'error', (err, msg) =>
       @invokeErrorHandlers(err, msg)
-    process.on 'uncaughtException', (err) =>
-      @emit 'error', err
+    process.on 'uncaughtException', @emitError
 
 
   # Public: Adds a Listener that attempts to match incoming messages based on
@@ -336,6 +335,12 @@ class Robot
   helpCommands: ->
     @commands.sort()
 
+  # Private: reference function used to emit an error
+  #
+  # Returns nothing.
+  emitError: (err) =>
+    @emit 'error', err
+
   # Private: load help info from a loaded script.
   #
   # path - A String path to the file on disk.
@@ -441,6 +446,7 @@ class Robot
   # Returns nothing.
   shutdown: ->
     clearInterval @pingIntervalId if @pingIntervalId?
+    process.removeListener 'uncaughtException', @emitError
     @adapter.close()
     @brain.close()
 


### PR DESCRIPTION
#### Summary
Looks like instantiating a new Robot will attach an 'uncaughtException' handler to the main process object using an anonymous function.  This listener is never cleaned up, even when shutdown is explicitly called.  I've added a function emitError that can be referenced when removing the event listener.

#### Issue
The issue is that when a robot is created and shut down multiple times (my use case is unit tests, but there may be others) the event listener for 'uncaughtException' is never removed.  I'll specifically receive a warning in this when running my unit tests, you can see that in the travis-ci link below.  Feel free to use my plugin to reproduce.

#### Links 
Unit Tests with warning - https://travis-ci.org/aaronstaves/hubot-substitute/jobs/21996378.
Hubot script - https://github.com/aaronstaves/hubot-substitute
NPM - https://www.npmjs.org/package/hubot-substitute