### PR TITLE
Added recent messages function in campfire adapter.

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -177,6 +177,9 @@ class CampfireStreaming extends EventEmitter
       body = { message: { "body":text, "type":type } }
       self.post "/room/#{id}/speak", body, callback
 
+    recentMessages: (limit, callback) ->
+      self.get "/room/#{id}/recent?limit=#{limit}", callback
+
     # listen for activity in channels
     listen: ->
       headers =


### PR DESCRIPTION
This function returns recent message from current room.
Params:
  limit: number of messages returned
  callback: result
Example:
  robot.adapter.bot.Room(msg.message.room).recentMessages 2, (error, data) ->
    msg.send data

Campfire API (recent messages): https://github.com/basecamp/campfire-api/blob/master/sections/messages.md#get-recent-messages
