### PR TITLE
Update express to fix loosely pinned downstream dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "optparse":           "1.0.4",
     "scoped-http-client": "0.9.8",
     "log":                "1.4.0",
-    "express":            "3.3.4"
+    "express":            "3.4.8"
   },
 
   "engines": {


### PR DESCRIPTION
Re-shrinkwrapped my hubot this morning and found this crash error on heroku:

```
2014-06-05T18:17:00.920746+00:00 heroku[web.1]: State changed from crashed to starting
2014-06-05T18:17:06.781727+00:00 app[web.1]: SyntaxError: Error parsing /app/node_modules/hubot/node_modules/express/node_modules/debug/node_modules/ms/package.json: Unexpected end of input
2014-06-05T18:17:06.781752+00:00 app[web.1]:   at Function.Module._resolveFilename (module.js:336:25)
2014-06-05T18:17:06.781751+00:00 app[web.1]:   at Function.Module._findPath (module.js:190:18)
2014-06-05T18:17:06.781745+00:00 app[web.1]:   at Object.parse (native)
2014-06-05T18:17:06.781748+00:00 app[web.1]:   at readPackage (module.js:113:52)
2014-06-05T18:17:06.781749+00:00 app[web.1]:   at tryPackage (module.js:123:13)
// ...
```

```diff
[33md5879bc[m -[31m[m Add grunt-release branch to bump shrinkwrap version. 

// ...

diff --git a/npm-shrinkwrap.json b/npm-shrinkwrap.json
index 884a7ff..c4b701b 100644
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -145,20 +148,29 @@
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
             },
             "debug": {
-              "version": "0.8.1",
-              "from": "debug@*"
+              "version": "1.0.0",
+              "from": "debug@*",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
             }
           }
         }
       }
     },
     "hubot-auth": {

// ...

```

Seems that the express version that hubot is using (v3.3.4), has a wildcard for `debug`:
https://github.com/visionmedia/express/blob/3.3.4/package.json#L35

This allowed a sneaky version bump from v0.8.1 to v1.0.0, which has the suspect `ms` package seen in the error.

The next minor version that constrains the `debug`package is v3.4.8:
https://github.com/visionmedia/express/blob/3.4.8/package.json#L36

I'll test it out and submit a PR, if that sounds alright.

Here's the CHANGELOG diff, but it should be anything breaking:
https://github.com/visionmedia/express/compare/3.3.4...3.4.8#diff-e1bbd4f15e3b63427b4261e05b948ea8R16