### PR TITLE
add functionality of logging to file

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -10,15 +10,17 @@ OptParse = require 'optparse'
 Path     = require 'path'
 
 Switches = [
-  [ "-a", "--adapter ADAPTER", "The Adapter to use" ],
-  [ "-c", "--create PATH",     "Create a deployable hubot" ],
-  [ "-d", "--disable-httpd",   "Disable the HTTP server" ],
-  [ "-h", "--help",            "Display the help information" ],
-  [ "-l", "--alias ALIAS",     "Enable replacing the robot's name with alias" ],
-  [ "-n", "--name NAME",       "The name of the robot in chat" ],
-  [ "-r", "--require PATH",    "Alternative scripts path" ],
-  [ "-t", "--config-check",    "Test hubot's config to make sure it won't fail at startup"]
-  [ "-v", "--version",         "Displays the version of hubot installed" ]
+  [ "-a", "--adapter ADAPTER",          "The Adapter to use" ],
+  [ "-c", "--create PATH",              "Create a deployable hubot" ],
+  [ "-d", "--disable-httpd",            "Disable the HTTP server" ],
+  [ "-h", "--help",                     "Display the help information" ],
+  [ "-l", "--alias ALIAS",              "Enable replacing the robot's name with alias" ],
+  [ "-n", "--name NAME",                "The name of the robot in chat" ],
+  [ "-r", "--require PATH",             "Alternative scripts path" ],
+  [ "-t", "--config-check",             "Test hubot's config to make sure it won't fail at startup"],
+  [ "-v", "--version",                  "Displays the version of hubot installed" ],
+  [ "-p", "--log-level LOG_LEVEL",      "The level of logging"],
+  [ "-f", "--log-file LOG_FILE",        "File path where logging info will be written to"]
 ]
 
 Options =
@@ -30,6 +32,8 @@ Options =
   name:        process.env.HUBOT_NAME    or "Hubot"
   path:        process.env.HUBOT_PATH    or "."
   configCheck: false
+  logLevel:    process.env.HUBOT_LOG_LEVEL or "info"
+  logFile:     process.env.HUBOT_LOG_FILE
 
 Parser = new OptParse.OptionParser(Switches)
 Parser.banner = "Usage hubot [options]"
@@ -64,6 +68,12 @@ Parser.on "config-check", (opt) ->
 Parser.on "version", (opt, value) ->
   Options.version = true
 
+Parser.on "log-level", (opt, value) ->
+  Options.logLevel = value
+
+Parser.on "log-file", (opt, value) ->
+  Options.logFile = value
+
 Parser.parse process.argv
 
 unless process.platform is "win32"
@@ -77,7 +87,7 @@ if Options.create
 else
   adapterPath = Path.join __dirname, "..", "src", "adapters"
 
-  robot = Hubot.loadBot adapterPath, Options.adapter, Options.enableHttpd, Options.name
+  robot = Hubot.loadBot adapterPath, Options.adapter, Options.enableHttpd, Options.name, Options.logLevel, Options.logFile
 
   if Options.version
     console.log robot.version

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ case-insensitive, and can be prefixed with `@` or suffixed with `:`. These are e
 
 Hubot will print useful logging information to standard output window by default, and the default log level is set to 'info'. 
 
-While you may change the log level by a global variable `HUBOT_LOG_LEVEL`, the value could be one of the following depending on your requirement:
+While you may change the log level by a global variable `HUBOT_LOG_LEVEL` or command line option `--log-level` or `-p`, the value could be one of the following depending on your requirement:
 
 - emergency
 - alert
@@ -92,7 +92,7 @@ While you may change the log level by a global variable `HUBOT_LOG_LEVEL`, the v
 - info
 - debug
 
-You may also want to let the logging information write to a disk file instead of stdout by setting a file path to global variable `HUBOT_LOG_FILE`.
+You may also want to let the logging information write to a disk file instead of stdout by setting a file path to global variable `HUBOT_LOG_FILE` or command line option `--log-file` or `-f`.
 
 If you want to log your own script information with the same logging system, you can access the log object via `robot.logger` or `msg.robot.logger`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,25 @@ case-insensitive, and can be prefixed with `@` or suffixed with `:`. These are e
     @myhubot help
     myhubot: help
 
+## Logging
+
+Hubot will print useful logging information to standard output window by default, and the default log level is set to 'info'. 
+
+While you may change the log level by a global variable `HUBOT_LOG_LEVEL`, the value could be one of the following depending on your requirement:
+
+- emergency
+- alert
+- critical
+- error
+- warning
+- notice
+- info
+- debug
+
+You may also want to let the logging information write to a disk file instead of stdout by setting a file path to global variable `HUBOT_LOG_FILE`.
+
+If you want to log your own script information with the same logging system, you can access the log object via `robot.logger` or `msg.robot.logger`.
+
 ## Scripting
 
 Hubot's power comes through scripting. Read [docs/scripting.md](scripting.md) for the deal on bending hubot to your will using code.

--- a/index.coffee
+++ b/index.coffee
@@ -21,5 +21,5 @@ module.exports = {
   CatchAllMessage
 }
 
-module.exports.loadBot = (adapterPath, adapterName, enableHttpd, botName) ->
-  new Robot adapterPath, adapterName, enableHttpd, botName
+module.exports.loadBot = (adapterPath, adapterName, enableHttpd, botName, logLevel, logFile) ->
+  new Robot adapterPath, adapterName, enableHttpd, botName, logLevel, logFile

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -38,7 +38,7 @@ class Robot
   # name        - A String of the robot name, defaults to Hubot.
   #
   # Returns nothing.
-  constructor: (adapterPath, adapter, httpd, name = 'Hubot') ->
+  constructor: (adapterPath, adapter, httpd, name = 'Hubot', logLevel, logFile) ->
     @name      = name
     @events    = new EventEmitter
     @brain     = new Brain @
@@ -47,7 +47,7 @@ class Robot
     @Response  = Response
     @commands  = []
     @listeners = []
-    @logger    = @createLogger()
+    @logger    = @createLogger(logLevel, logFile)
 
     @parseVersion()
     if httpd
@@ -487,9 +487,8 @@ class Robot
   # are determined by Environment variables
   #
   # Returns a Log instance
-  createLogger: () ->
-    logLevel = process.env.HUBOT_LOG_LEVEL or 'info'
-    outStream = Fs.createWriteStream process.env.HUBOT_LOG_FILE, { flags: 'a' } if process.env.HUBOT_LOG_FILE?
+  createLogger: (logLevel, logFile) ->
+    outStream = Fs.createWriteStream logFile, { flags: 'a' } if logFile?
     new Log logLevel, outStream
 
 module.exports = Robot

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -47,7 +47,7 @@ class Robot
     @Response  = Response
     @commands  = []
     @listeners = []
-    @logger    = new Log process.env.HUBOT_LOG_LEVEL or 'info'
+    @logger    = @createLogger()
 
     @parseVersion()
     if httpd
@@ -482,5 +482,14 @@ class Robot
   http: (url) ->
     HttpClient.create(url)
       .header('User-Agent', "Hubot/#{@version}")
+
+  # Private: Creates a Log instance, the Log level and Output stream
+  # are determined by Environment variables
+  #
+  # Returns a Log instance
+  createLogger: () ->
+    logLevel = process.env.HUBOT_LOG_LEVEL or 'info'
+    outStream = Fs.createWriteStream process.env.HUBOT_LOG_FILE, { flags: 'a' } if process.env.HUBOT_LOG_FILE?
+    new Log logLevel, outStream
 
 module.exports = Robot


### PR DESCRIPTION
Hi guys,

I am feeling it is quite useful to make logs be persisted to disk files rather that only print to stdout. Especially when I also want to use robot.logger to log some script layer information, I would like to have it be kept on file and with hubot internal logging information.

So the easiest way of achieving this is simply use a global variable HUBOT_LOG_FILE, if it is specified, then we will construct a Log instance with a file stream.

Hope this make sense to you, Thanks a lot!
