### PR TITLE
update coffee-script v1.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
 
   "dependencies": {
-    "coffee-script":      "1.6.3",
+    "coffee-script":      "^1.8",
     "optparse":           "1.0.4",
     "scoped-http-client": "0.9.8",
     "log":                "1.4.0",


### PR DESCRIPTION
I want to use latest coffee-script npm.
I've tested all `scripts/*.coffee` in hubot template.