### PR TITLE
Add Support for EXPRESS_PORT Variable

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -402,7 +402,7 @@ module.exports = (robot) ->
 
 ## HTTP Listener
 
-Hubot includes support for the [express](http://expressjs.com/guide.html) web framework to serve up HTTP requests. It listens on the port specified by the `PORT` environment variable, and defaults to 8080. An instance of an express application is available at `robot.router`. It can be protected with username and password by specifying `EXPRESS_USER` and `EXPRESS_PASSWORD`. It can automatically serve static files by setting `EXPRESS_STATIC`.
+Hubot includes support for the [express](http://expressjs.com/guide.html) web framework to serve up HTTP requests. It listens on the port specified by the `EXPRESS_PORT` or `PORT` environment variables (preferred in that order) and defaults to 8080. An instance of an express application is available at `robot.router`. It can be protected with username and password by specifying `EXPRESS_USER` and `EXPRESS_PASSWORD`. It can automatically serve static files by setting `EXPRESS_STATIC`.
 
 The most common use of this is for providing HTTP end points for services with webhooks to push to, and have those show up in chat.
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -270,7 +270,7 @@ class Robot
     pass    = process.env.EXPRESS_PASSWORD
     stat    = process.env.EXPRESS_STATIC
     port    = process.env.EXPRESS_PORT or process.env.PORT or 8080
-    address = process.env.BIND_ADDRESS or '0.0.0.0'
+    address = process.env.EXPRESS_BIND_ADDRESS or process.env.BIND_ADDRESS or '0.0.0.0'
 
     express = require 'express'
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -269,6 +269,8 @@ class Robot
     user    = process.env.EXPRESS_USER
     pass    = process.env.EXPRESS_PASSWORD
     stat    = process.env.EXPRESS_STATIC
+    port    = process.env.EXPRESS_PORT or process.env.PORT or 8080
+    address = process.env.BIND_ADDRESS or '0.0.0.0'
 
     express = require 'express'
 
@@ -284,7 +286,7 @@ class Robot
     app.use express.static stat if stat
 
     try
-      @server = app.listen(process.env.PORT || 8080, process.env.BIND_ADDRESS || '0.0.0.0')
+      @server = app.listen(port, address)
       @router = app
     catch err
       @logger.error "Error trying to start HTTP server: #{err}\n#{err.stack}"


### PR DESCRIPTION
As discussed in #728, this PR adds support for an `EXPRESS_PORT` variable to set the port for Express to listen on while also retaining support for the current `PORT` variable. `EXPRESS_PORT` will be favored over `PORT`. My only outstanding question is whether we should also add `EXPRESS_BIND_ADDRESS` - this hasn't been an issue I've run into, but it might be nice for the sake of consistency.

cc: @technicalpickles