### PR TITLE
Stop listening to uncaughtException events on shutdown

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -63,9 +63,9 @@ class Robot
 
     @on 'error', (err, msg) =>
       @invokeErrorHandlers(err, msg)
-    process.on 'uncaughtException', (err) =>
+    @onUncaughtException = (err) =>
       @emit 'error', err
-
+    process.on 'uncaughtException', @onUncaughtException
 
   # Public: Adds a Listener that attempts to match incoming messages based on
   # a Regex.
@@ -447,6 +447,7 @@ class Robot
   # Returns nothing.
   shutdown: ->
     clearInterval @pingIntervalId if @pingIntervalId?
+    process.removeListener 'uncaughtException', @onUncaughtException
     @adapter.close()
     @brain.close()
 


### PR DESCRIPTION
I noticed this when running tests for a Hubot instance that created a lot of `Robot` instances. Eventually Node warned that there were more than 10 listeners for the `uncaughtException` event.

/cc @technicalpickles 