### PR TITLE
Bumping to use CoffeeScript 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/github/hubot.git"
   },
   "dependencies": {
-    "coffee-script": "1.6.3",
+    "coffee-script": "1.9.0",
     "optparse": "1.0.4",
     "scoped-http-client": "0.10.0",
     "log": "1.4.0",


### PR DESCRIPTION
CoffeeScript 1.9.0 came out Jan 29, 2015.  We are using 1.6.3 which is from Jun 2, 2013 and is quite old.

Some new features that I would like to use while building scripts are the 

[Splat Expansions:](https://github.com/jashkenas/coffeescript/blob/1.9.0/test/arrays.coffee#L62-L71)

```coffeescript
    [.., rel] = link.match /rel="(\w+)"/
```

I can't currently do this with coffee-script 1.6.3.

This is my first fix for hubot, so I'm not 100% sure on the procedure.  I saw a test folder, but not sure how to interact with the tests.  The only test that I did run was my script and it worked.  I also ran `script/smoke-test` and nothing blew up.