### PR TITLE
Reimplement shell adapter using cline and chalk, and fix persistent history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.hubot_history

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/github/hubot.git"
   },
   "dependencies": {
+    "chalk": "^1.0.0",
     "cline": "^0.8.1",
     "coffee-script": "1.6.3",
     "express": "3.18.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "cline": "^0.8.1",
+    "cline": "^0.8.2",
     "coffee-script": "1.6.3",
     "express": "3.18.1",
     "log": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,21 +20,20 @@
     "url": "https://github.com/github/hubot.git"
   },
   "dependencies": {
+    "cline": "^0.8.1",
     "coffee-script": "1.6.3",
-    "optparse": "1.0.4",
-    "scoped-http-client": "0.10.0",
-    "log": "1.4.0",
     "express": "3.18.1",
-    "readline-history": "~1.2.0"
+    "log": "1.4.0",
+    "optparse": "1.0.4",
+    "readline-history": "~1.2.0",
+    "scoped-http-client": "0.10.0"
   },
-
   "devDependencies": {
     "hubot-mock-adapter": "^1.0.0",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
     "sinon-chai": "^2.6.0"
   },
-
   "engines": {
     "node": ">= 0.8.x",
     "npm": ">= 1.1.x"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "express": "3.18.1",
     "log": "1.4.0",
     "optparse": "1.0.4",
-    "readline-history": "~1.2.0",
     "scoped-http-client": "0.10.0"
   },
   "devDependencies": {

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -1,7 +1,8 @@
-cline    = require('cline')
 fs       = require('fs')
 readline = require('readline')
 stream   = require('stream')
+cline    = require('cline')
+chalk    = require('chalk')
 
 Robot         = require '../robot'
 Adapter       = require '../adapter'
@@ -14,10 +15,7 @@ historySize = if process.env.HUBOT_SHELL_HISTSIZE?
 
 class Shell extends Adapter
   send: (envelope, strings...) ->
-    unless process.platform is 'win32'
-      console.log "\x1b[01;32m#{str}\x1b[0m" for str in strings
-    else
-      console.log "#{str}" for str in strings
+    console.log chalk.green.bold("#{str}") for str in strings
 
   emote: (envelope, strings...) ->
     @send envelope, "* #{str}" for str in strings

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -57,8 +57,6 @@ class Shell extends Adapter
 
     @cli.on 'history', (item) =>
       if item.length > 0 and item isnt 'exit' and item isnt 'history'
-        console.log "adding #{item} to the history"
-
         fs.appendFile '.hubot_history', "#{item}\n", (err) =>
           @robot.emit 'error', err if err
 

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -13,6 +13,8 @@ historySize = if process.env.HUBOT_SHELL_HISTSIZE?
               else
                 1024
 
+historyPath = ".hubot_history"
+
 class Shell extends Adapter
   send: (envelope, strings...) ->
     console.log chalk.green.bold("#{str}") for str in strings
@@ -50,7 +52,7 @@ class Shell extends Adapter
 
     @cli.on 'history', (item) =>
       if item.length > 0 and item isnt 'exit' and item isnt 'history'
-        fs.appendFile '.hubot_history', "#{item}\n", (err) =>
+        fs.appendFile historyPath, "#{item}\n", (err) =>
           @robot.emit 'error', err if err
 
     @cli.on 'close', () =>
@@ -59,7 +61,7 @@ class Shell extends Adapter
         startIndex = history.length - historySize
         history = history.reverse().splice(startIndex, historySize)
 
-        outstream = fs.createWriteStream('.hubot_history')
+        outstream = fs.createWriteStream(historyPath)
         # >= node 0.10
         outstream.on 'finish', () =>
           @shutdown()
@@ -74,9 +76,9 @@ class Shell extends Adapter
          @shutdown()
 
   loadHistory: (callback) ->
-    fs.exists '.hubot_history', (exists) ->
+    fs.exists historyPath, (exists) ->
       if exists
-        instream = fs.createReadStream('.hubot_history')
+        instream = fs.createReadStream(historyPath)
         outstream = new stream
         outstream.readable = true
         outstream.writable = true

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -1,8 +1,7 @@
-Cline = require('cline')
-fs    = require('fs')
+cline    = require('cline')
+fs       = require('fs')
 readline = require('readline')
-stream = require('stream')
-util = require('util')
+stream   = require('stream')
 
 Robot         = require '../robot'
 Adapter       = require '../adapter'
@@ -12,7 +11,6 @@ historySize = if process.env.HUBOT_SHELL_HISTSIZE?
                 parseInt(process.env.HUBOT_SHELL_HISTSIZE)
               else
                 1024
-
 
 class Shell extends Adapter
   send: (envelope, strings...) ->
@@ -41,7 +39,7 @@ class Shell extends Adapter
     process.exit 0
 
   buildCli: () ->
-    @cli = Cline()
+    @cli = cline()
 
     @cli.command '*', (input) =>
       userId = parseInt(process.env.HUBOT_SHELL_USER_ID or '1')

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -75,6 +75,9 @@ class Shell extends Adapter
        else
          @shutdown()
 
+  # Private: load history from .hubot_history.
+  #
+  # callback - A Function that is called with the loaded history items (or an empty array if there is no history)
   loadHistory: (callback) ->
     fs.exists historyPath, (exists) ->
       if exists

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -36,7 +36,7 @@ class Shell extends Adapter
       @cli.interact("#{@robot.name}> ")
       @emit 'connected'
 
-  finish: () ->
+  shutdown: () ->
     @robot.shutdown()
     process.exit 0
 
@@ -71,16 +71,16 @@ class Shell extends Adapter
         outstream = fs.createWriteStream('.hubot_history')
         # >= node 0.10
         outstream.on 'finish', () =>
-          @finish()
+          @shutdown()
 
         for item in history
           outstream.write "#{item}\n"
 
         # < node 0.10
         outstream.end () =>
-          @finish()
+          @shutdown()
        else
-         @finish
+         @shutdown()
 
   loadHistory: (callback) ->
     fs.exists '.hubot_history', (exists) ->

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -26,12 +26,15 @@ class Shell extends Adapter
   run: ->
     @cli = Cline()
 
-    @cli.command '*', (input) =>
+    @cli.command "*", (input) =>
       console.log "got #{input}"
       user_id = parseInt(process.env.HUBOT_SHELL_USER_ID or '1')
       user_name = process.env.HUBOT_SHELL_USER_NAME or 'Shell'
       user = @robot.brain.userForId user_id, name: user_name, room: 'Shell'
       @receive new TextMessage user, input, 'messageId'
+
+    # workaround https://github.com/kucoe/cline/issues/5
+    @cli.commands['*'] = @cli.commands['\\*']
 
     @cli.command 'history', () =>
       console.log @cli.history()

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -45,9 +45,6 @@ class Shell extends Adapter
       user = @robot.brain.userForId userId, name: userName, room: 'Shell'
       @receive new TextMessage user, input, 'messageId'
 
-    # workaround https://github.com/kucoe/cline/issues/5
-    @cli.commands['*'] = @cli.commands['\\*']
-
     @cli.command 'history', () =>
       console.log item for item in @cli.history()
 

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -94,8 +94,5 @@ class Shell extends Adapter
       else
         callback([])
 
-
-
-
 exports.use = (robot) ->
   new Shell robot

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -69,8 +69,7 @@ class Shell extends Adapter
         console.log "adding #{item} to the history"
 
         fs.appendFile '.hubot_history', "#{item}\n", (err) =>
-          @robot.emit 'error', err
-
+          @robot.emit 'error', err if err
 
     @cli.on 'close', () =>
       console.log "on close!"


### PR DESCRIPTION
https://github.com/github/hubot/pull/800 introduced a persistent history for the shell adapter. The main reason for this was to make it a bit easier to iterate in development, but it has caused other problems, particularly it's 

As @robert-rally pointed out about readline-history:

> It's a bad monkey-patch that assumes readLine.history is always initialized. Spoiler alert: it isn't.

This should fix https://github.com/github/hubot/issues/826 and https://github.com/github/hubot/issues/845 . It replaces using readline and readline-history with [cline](https://github.com/kucoe/cline), because it has a lot better interface. In particular, it does have a hook to managing a history. I just had to write some code to load it initially, and to truncate it at the end.

I also replaced the hard-coded terminal color output with [chalk](https://github.com/sindresorhus/chalk), so it's a lot easier to know what it's even doing.

cc @benbalter @keithduncan @viking @robert-rally who have run into problems in one way or another