### PR TITLE
Add support for global http options

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -72,7 +72,8 @@ In many corporate environments, a web proxy is required to access the Internet a
 Due to the way node.js handles HTTP and HTTPS requests, you need to specify a different Agent for each protocol. ScopedHTTPClient will then automatically choose the right ProxyAgent for each request.
 
 ```coffeescript
+proxy = require 'proxy-agent'
 module.export = (robot) ->
-  robot.globalHttpOptions.httpAgent  = new ProxyAgent('http://my-proxy-server.internal', false)
-  robot.globalHttpOptions.httpsAgent = new ProxyAgent('http://my-proxy-server.internal', true)
+  robot.globalHttpOptions.httpAgent  = proxy('http://my-proxy-server.internal', false)
+  robot.globalHttpOptions.httpsAgent = proxy('http://my-proxy-server.internal', true)
 ```

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -64,3 +64,15 @@ module.exports = (robot) ->
     return
 
 ```
+
+## Forwarding all HTTP requests through a proxy
+
+In many corporate environments, a web proxy is required to access the Internet and/or protected resources. For one-off control, use can specify an [Agent](https://nodejs.org/api/http.html) to use with `robot.http`. However, this would require modifying every script your robot uses to point at the proxy. Instead, you can specify the agent at the global level and have all HTTP requests use the agent by default.
+
+Due to the way node.js handles HTTP and HTTPS requests, you need to specify a different Agent for each protocol. ScopedHTTPClient will then automatically choose the right ProxyAgent for each request.
+
+```coffeescript
+module.export = (robot) ->
+  robot.globalHttpOptions.httpAgent  = new ProxyAgent('http://my-proxy-server.internal', false)
+  robot.globalHttpOptions.httpsAgent = new ProxyAgent('http://my-proxy-server.internal', true)
+```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "3.18.1",
     "log": "1.4.0",
     "optparse": "1.0.4",
-    "scoped-http-client": "0.10.3"
+    "scoped-http-client": "0.11.0"
   },
   "devDependencies": {
     "hubot-mock-adapter": "^1.0.0",

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -49,6 +49,7 @@ class Robot
     @listeners = []
     @logger    = new Log process.env.HUBOT_LOG_LEVEL or 'info'
     @pingIntervalId = null
+    @globalHttpOptions = {}
 
     @parseVersion()
     if httpd
@@ -493,7 +494,16 @@ class Robot
   #
   # Returns a ScopedClient instance.
   http: (url, options) ->
-    HttpClient.create(url, options)
+    HttpClient.create(url, @extend({}, @globalHttpOptions, options))
       .header('User-Agent', "Hubot/#{@version}")
+
+  # Private: Extend obj with objects passed as additional args.
+  #
+  # Returns the original object with updated changes.
+  extend: (obj, sources...) ->
+    for source in sources
+      obj[key] = value for own key, value of source
+    obj
+
 
 module.exports = Robot

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -12,6 +12,8 @@ Robot = require '../src/robot.coffee'
 { CatchAllMessage, EnterMessage, TextMessage } = require '../src/message'
 Adapter = require '../src/adapter'
 
+ScopedHttpClient = require 'scoped-http-client'
+
 # Preload the Hubot mock adapter but substitute in the latest version of Adapter
 mockery.enable()
 mockery.registerAllowable 'hubot-mock-adapter'
@@ -40,6 +42,25 @@ describe 'Robot', ->
    @robot.shutdown()
 
   describe 'Unit Tests', ->
+    describe '#http', ->
+      beforeEach ->
+        url = 'http://localhost'
+        @httpClient = @robot.http(url)
+
+      it 'creates a new ScopedHttpClient', ->
+        # 'instanceOf' check doesn't work here due to the design of
+        # ScopedHttpClient
+        expect(@httpClient).to.have.property('get')
+        expect(@httpClient).to.have.property('post')
+
+      it 'passes options through to the ScopedHttpClient', ->
+        agent = {}
+        httpClient = @robot.http('http://localhost', agent: agent)
+        expect(httpClient.options.agent).to.equal(agent)
+
+      it 'sets a sane user agent', ->
+        expect(@httpClient.options.headers['User-Agent']).to.contain('Hubot')
+
     describe '#receive', ->
       it 'calls all registered listeners', ->
         # Need to use a real Message so that the CatchAllMessage constructor works

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -61,6 +61,19 @@ describe 'Robot', ->
       it 'sets a sane user agent', ->
         expect(@httpClient.options.headers['User-Agent']).to.contain('Hubot')
 
+      it 'merges in any global http options', ->
+        agent = {}
+        @robot.globalHttpOptions = {agent: agent}
+        httpClient = @robot.http('http://localhost')
+        expect(httpClient.options.agent).to.equal(agent)
+
+      it 'local options override global http options', ->
+        agentA = {}
+        agentB = {}
+        @robot.globalHttpOptions = {agent: agentA}
+        httpClient = @robot.http('http://localhost', agent: agentB)
+        expect(httpClient.options.agent).to.equal(agentB)
+
     describe '#receive', ->
       it 'calls all registered listeners', ->
         # Need to use a real Message so that the CatchAllMessage constructor works


### PR DESCRIPTION
Primary purpose is to support global proxy settings in corporate environments

Closes #287 and #731 