### PR TITLE
Trim lines from .hubot_history

### DIFF
--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -89,6 +89,7 @@ class Shell extends Adapter
         items = []
         rl = readline.createInterface(input: instream, output: outstream, terminal: false)
         rl.on 'line', (line) ->
+          line = line.trim()
           if line.length > 0 
             items.push(line)
         rl.on 'close', () ->


### PR DESCRIPTION
I tested the new shell adapter on node 0.8, and found navigating back in the history was including a newline. This trims the line.