### PR TITLE
Eliminate "connect deprecated multipart" and "connect deprecated limit:" warnings

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -288,7 +288,13 @@ class Robot
 
     app.use express.basicAuth user, pass if user and pass
     app.use express.query()
-    app.use express.bodyParser()
+
+    # Removing bodyParser since it's deprecated
+    # Note that Hubot no longer supports multipart uploads due to no longer using express.bodyParser
+    # In order to put support back for that, we would need to use one of: formidable, multiparty, busboy, multer, etc.
+    app.use express.urlencoded()
+    app.use express.json()
+
     app.use express.static stat if stat
 
     try


### PR DESCRIPTION
This replaces the deprecated express.bodyParser() with express.urlencoded() and express.json()

This gets rid of the two warnings reported in #828:
```
connect deprecated multipart: use parser (multiparty, busboy, formidable) npm module instead node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:56:20
connect deprecated limit: Restrict request size at location of read node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/multipart.js:86:15
```

(That issue was closed, but IMO the problem remains: These warnings are red herrings that serve to scare new users when something isn't working.)

express.bodyParser() is deprecated in favor of only using the parts you need.
I've replaced it with only the parsing bits that I believe Hubot is using: url encoded and json.
If Hubot does in fact need to parse multipart uploads, this patch will not work.