### PR TITLE
Update deploying docs with md file extension

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -3,6 +3,6 @@ permalink: /docs/deploying/index.html
 layout: docs
 ---
 
-- [Heroku](/docs/deploying/heroku/)
-- [Unix](/docs/deploying/unix/)
-- [Windows](/docs/deploying/windows/)
+- [Heroku](/docs/deploying/heroku.md)
+- [Unix](/docs/deploying/unix.md)
+- [Windows](/docs/deploying/windows.md)


### PR DESCRIPTION
Clicking these links on master are broken, but the docs they meant to refer to are in /docs/deploying but only the extensions (.md) were missing. They are fixed now, and the links would work routing to the appropriate doc sheet.