### PR TITLE
Fixed deploying doc links for heroku, unix and windows

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -3,6 +3,6 @@ permalink: /docs/deploying/index.html
 layout: docs
 ---
 
-- [Heroku](/docs/deploying/heroku/)
-- [Unix](/docs/deploying/unix/)
-- [Windows](/docs/deploying/windows/)
+- [Heroku](/docs/deploying/heroku.md)
+- [Unix](/docs/deploying/unix.md)
+- [Windows](/docs/deploying/windows.md)


### PR DESCRIPTION
The deploying docs for Heroku, Unix and Windows were pointing to a folder instead of the markdown files. This pull request fixes them.