### PR TITLE
Followup: Eliminate "connect deprecated multipart" and "connect deprecated limit:" warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "chalk": "^1.0.0",
     "cline": "^0.8.2",
     "coffee-script": "1.6.3",
+    "connect-multiparty": "^1.2.5",
     "express": "3.18.1",
     "log": "1.4.0",
     "optparse": "1.0.4",

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -292,7 +292,9 @@ class Robot
 
     app.use express.json()
     app.use express.urlencoded()
-    app.use multipart()
+    # replacement for deprecated express.multipart/connect.multipart
+    # limit to 100mb, as per the old behavior
+    app.use multipart(maxFilesSize: 100 * 1024 * 1024)
 
     app.use express.static stat if stat
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -279,6 +279,7 @@ class Robot
     address = process.env.EXPRESS_BIND_ADDRESS or process.env.BIND_ADDRESS or '0.0.0.0'
 
     express = require 'express'
+    multipart = require 'connect-multiparty'
 
     app = express()
 
@@ -289,11 +290,9 @@ class Robot
     app.use express.basicAuth user, pass if user and pass
     app.use express.query()
 
-    # Removing bodyParser since it's deprecated
-    # Note that Hubot no longer supports multipart uploads due to no longer using express.bodyParser
-    # In order to put support back for that, we would need to use one of: formidable, multiparty, busboy, multer, etc.
-    app.use express.urlencoded()
     app.use express.json()
+    app.use express.urlencoded()
+    app.use multipart()
 
     app.use express.static stat if stat
 


### PR DESCRIPTION
This addresses some of my comments in https://github.com/github/hubot/pull/899 , primarily about maintaining backwards compatability.

This uses the connect-multiparty middleware, and sets a default to 100mb, like connect.multipart used to. I also preserved the order of middleware that connect.bodyParser implied.

cc @Taytay @cbelsole