### PR TITLE
Prepare for v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v2.12.0
+=======
+
+* Update scripting documentation to ref to `res` instead of `msg`, since it's a `Response` object
+* Update scoped-http-client from 0.10.0 to 0.10.3
+* Fix deprecation warnings from connect at startup
+
 v2.11.4
 =======
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "2.11.4",
+  "version": "2.12.0",
   "author": "hubot",
   "keywords": [
     "github",


### PR DESCRIPTION
Featuring:

* Update documentation to use `res` instead of `msg` cc https://github.com/github/hubot/pull/888 @geoffreyanderson
* Bump scoped-http-client from 0.10.0 to 0.10.3 cc https://github.com/github/hubot/pull/908 @keithduncan 
* Eliminate "connect deprecated multipart" and "connect deprecated limit:" warnings  cc https://github.com/github/hubot/pull/899 https://github.com/github/hubot/issues/914 @Taytay 