### PR TITLE
Fix #862 - Sorts Help Commands by Script

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -45,7 +45,7 @@ class Robot
     @alias     = false
     @adapter   = null
     @Response  = Response
-    @commands  = []
+    @commands  = {}
     @listeners = []
     @logger    = new Log process.env.HUBOT_LOG_LEVEL or 'info'
     @pingIntervalId = null
@@ -343,7 +343,10 @@ class Robot
   #
   # Returns an Array of help commands for running scripts.
   helpCommands: ->
-    @commands.sort()
+    output = []
+    for script, cmds of @commands
+      output = output.concat(cmds.sort())
+    return output
 
   # Private: load help info from a loaded script.
   #
@@ -354,7 +357,7 @@ class Robot
     @logger.debug "Parsing help for #{path}"
     scriptName = Path.basename(path).replace /\.(coffee|js)$/, ''
     scriptDocumentation = {}
-
+    @commands[scriptName] = []
     body = Fs.readFileSync path, 'utf-8'
 
     currentSection = null
@@ -374,7 +377,7 @@ class Robot
         if currentSection
           scriptDocumentation[currentSection].push cleanedLine.trim()
           if currentSection is 'commands'
-            @commands.push cleanedLine.trim()
+            @commands[scriptName].push cleanedLine.trim()
 
     if currentSection is null
       @logger.info "#{path} is using deprecated documentation syntax"
@@ -384,7 +387,7 @@ class Robot
         continue if not line.match('-')
         cleanedLine = line[2..line.length].replace(/^hubot/i, @name).trim()
         scriptDocumentation.commands.push cleanedLine
-        @commands.push cleanedLine
+        @commands[scriptName].push cleanedLine
 
   # Public: A helper send function which delegates to the adapter's send
   # function.


### PR DESCRIPTION
This changes @commands from [] → {} which keeps track of each script
as they are loaded. Then `helpCommands` returns an array after calling
sort() on the commands of each script, rather than all scripts at once.

Note that this means that the command `hubot help <TERM>` will show
commands sorted by script still, since the filtering is done in the help
script. A simple solution would be to have the help scripts call sort()
after filtering, but this, of course, wouldn't be applied to existing
installations.
