### PR TITLE
Fix link to developing adapters

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -47,4 +47,4 @@ to have yours added to the list:
 
 ## Writing Your Own Adapter
 
-Interested in adding your own adapter? Check out our documentation for [developing adapters](/docs/adapters/development/)
+Interested in adding your own adapter? Check out our documentation for [developing adapters](/docs/adapters/development.md)


### PR DESCRIPTION
Figured I should fix it after the third time I clicked on it.