### PR TITLE
Hooks

### DIFF
--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -1,0 +1,29 @@
+class Hook
+  constructor: (opts) ->
+    @context =
+      response: opts.response
+      listener: opts.listener
+      message:  opts.message
+      robot:    opts.robot
+      done:     @done
+      next:     @next
+    @hooks    = opts.hooks.slice 0 # make a shallow clone
+    @callback = opts.callback
+
+  run: ->
+    nextHook = @hooks.shift()
+    if nextHook?
+      nextHook(@context)
+    else
+      @callback()
+
+  done: =>
+    @context.message.finish()
+    @callback()
+
+  next: =>
+    @run()
+
+module.exports = {
+  Hook
+}

--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -1,30 +1,27 @@
 class Hook
   constructor: (opts) ->
-    @context =
-      response: opts.response
-      listener: opts.listener
-      message:  opts.message
-      robot:    opts.robot
-      reply:    opts.reply
-      finish:   @finish
-      next:     @next
+    @response = opts.response
+    @listener = opts.listener
+    @message  = opts.message
+    @robot    = opts.robot
+    @reply    = opts.reply
     @hooks    = opts.hooks.slice 0 # make a shallow clone
     @callback = opts.callback
 
   run: ->
     nextHook = @hooks.shift()
     if nextHook?
-      nextHook(@context)
+      nextHook(@)
     else
       @callback()
 
   finish: =>
-    if @context.reply
+    if @reply?
       # We're processing a reply, not a listen or receive. The message has
       # been processed, so it's too late to finish() it. By not calling
       # @run() or @callback() we end processing and do not send the reply.
     else
-      @context.message.finish()
+      @message.finish()
       @callback()
 
   next: =>

--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -5,13 +5,15 @@ class Hook
     @message  = opts.message
     @robot    = opts.robot
     @reply    = opts.reply
-    @hooks    = opts.hooks.slice 0 # make a shallow clone
+    @hooks    = opts.hooks
     @callback = opts.callback
+    @nextHook = -1
 
   run: ->
-    nextHook = @hooks.shift()
-    if nextHook?
-      nextHook(@)
+    @nextHook += 1
+    hook = @hooks[@nextHook]
+    if hook?
+      hook(@)
     else
       @callback()
 

--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -5,6 +5,7 @@ class Hook
       listener: opts.listener
       message:  opts.message
       robot:    opts.robot
+      reply:    opts.reply
       finish:   @finish
       next:     @next
     @hooks    = opts.hooks.slice 0 # make a shallow clone
@@ -18,8 +19,13 @@ class Hook
       @callback()
 
   finish: =>
-    @context.message.finish()
-    @callback()
+    if @context.reply
+      # We're processing a reply, not a listen or receive. The message has
+      # been processed, so it's too late to finish() it. By not calling
+      # @run() or @callback() we end processing and do not send the reply.
+    else
+      @context.message.finish()
+      @callback()
 
   next: =>
     @run()

--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -5,7 +5,7 @@ class Hook
       listener: opts.listener
       message:  opts.message
       robot:    opts.robot
-      done:     @done
+      finish:   @finish
       next:     @next
     @hooks    = opts.hooks.slice 0 # make a shallow clone
     @callback = opts.callback
@@ -17,7 +17,7 @@ class Hook
     else
       @callback()
 
-  done: =>
+  finish: =>
     @context.message.finish()
     @callback()
 

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -21,10 +21,13 @@ class Listener
   # Returns a boolean of whether the matcher matched.
   call: (message) ->
     if match = @matcher message
+
       @robot.logger.debug \
         "Message '#{message}' matched regex /#{inspect @regex}/" if @regex
 
-      @callback new @robot.Response(@robot, message, match)
+      response = new @robot.Response(@robot, message, match)
+
+      @robot.runPrelistenHooks(this, response)
       true
     else
       false

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -19,7 +19,8 @@ class Response
   #
   # Returns nothing.
   send: (strings...) ->
-    @robot.adapter.send @envelope, strings...
+    for string in strings
+      @robot.runPrereplyHooks this, string, @robot.adapter.send
 
   # Public: Posts an emote back to the chat source
   #
@@ -28,7 +29,8 @@ class Response
   #
   # Returns nothing.
   emote: (strings...) ->
-    @robot.adapter.emote @envelope, strings...
+    for string in strings
+      @robot.runPrereplyHooks this, string, @robot.adapter.emote
 
   # Public: Posts a message mentioning the current user.
   #
@@ -37,7 +39,8 @@ class Response
   #
   # Returns nothing.
   reply: (strings...) ->
-    @robot.adapter.reply @envelope, strings...
+    for string in strings
+      @robot.runPrereplyHooks this, string, @robot.adapter.reply
 
   # Public: Posts a topic changing message
   #
@@ -46,7 +49,8 @@ class Response
   #
   # Returns nothing.
   topic: (strings...) ->
-    @robot.adapter.topic @envelope, strings...
+    for string in strings
+      @robot.runPrereplyHooks this, string, @robot.adapter.topic
 
   # Public: Play a sound in the chat source
   #
@@ -55,7 +59,8 @@ class Response
   #
   # Returns nothing
   play: (strings...) ->
-    @robot.adapter.play @envelope, strings...
+    for string in strings
+      @robot.runPrereplyHooks this, string, @robot.adapter.play
 
   # Public: Posts a message in an unlogged room
   #
@@ -64,7 +69,8 @@ class Response
   #
   # Returns nothing
   locked: (strings...) ->
-    @robot.adapter.locked @envelope, strings...
+    for string in strings
+      @robot.runPrereplyHooks this, string, @robot.adapter.locked
 
   # Public: Picks a random item from the given items.
   #

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -517,34 +517,6 @@ class Robot
     HttpClient.create(url, options)
       .header('User-Agent', "Hubot/#{@version}")
 
-  # Private. Run the hooks of a given name
-  #
-  #  name     - 'prereceive'
-  #  response - The response object
-  #  listener - The matching listener, if any
-  #  message  - A message that hubot is trying to send, if any
-  #
-  # Each hook must call hook.next() or hook.done(). Hook.next() continues
-  # processing and hook.done() aborts the message. If a response message
-  # exists, hook.done() prevents it from being sent.
-  #
-  # Returns nothing.
-  runHooks: (name, callback, message, response, listener, reply) ->
-    hooks = @hooks[name]
-    if hooks?.length > 0
-      opts =
-        hooks:    hooks
-        callback: callback
-        response: response
-        message:  message
-        listener: listener
-        robot:    this
-        reply:    reply
-      hook = new Hook(opts)
-      hook.run()
-    else
-      callback()
-
   # Public. Adds a prereceive callback hook to this robot.
   #
   #   cb  - A callback function which accepts a Hook object.
@@ -594,5 +566,33 @@ class Robot
     done = ->
       cb(response.envelope, string)
     @runHooks 'prereply', done, response.envelope.message, response, response.listener, string
+
+  # Private. Run the hooks of a given name
+  #
+  #  name     - 'prereceive'
+  #  response - The response object
+  #  listener - The matching listener, if any
+  #  message  - A message that hubot is trying to send, if any
+  #
+  # Each hook must call hook.next() or hook.done(). Hook.next() continues
+  # processing and hook.done() aborts the message. If a response message
+  # exists, hook.done() prevents it from being sent.
+  #
+  # Returns nothing.
+  runHooks: (name, callback, message, response, listener, reply) ->
+    hooks = @hooks[name]
+    if hooks?.length > 0
+      opts =
+        hooks:    hooks
+        callback: callback
+        response: response
+        message:  message
+        listener: listener
+        robot:    this
+        reply:    reply
+      hook = new Hook(opts)
+      hook.run()
+    else
+      callback()
 
 module.exports = Robot

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -61,8 +61,8 @@ class Robot
     @adapterName   = adapter
     @errorHandlers = []
 
-    @on 'error', (err, msg) =>
-      @invokeErrorHandlers(err, msg)
+    @on 'error', (err, res) =>
+      @invokeErrorHandlers(err, res)
     @onUncaughtException = (err) =>
       @emit 'error', err
     process.on 'uncaughtException', @onUncaughtException

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -529,13 +529,15 @@ class Robot
   # exists, hook.done() prevents it from being sent.
   #
   # Returns nothing.
-  runHooks: (name, callback, message, reply) ->
+  runHooks: (name, callback, message, response, listener, reply) ->
     hooks = @hooks[name]
     if hooks?.length > 0
       opts =
         hooks:    hooks
         callback: callback
+        response: response
         message:  message
+        listener: listener
         robot:    this
         reply:    reply
       hook = new Hook(opts)
@@ -552,5 +554,25 @@ class Robot
   prereceive: (cb) ->
     @hooks['prereceive'] ||= []
     @hooks['prereceive'].push cb
+
+  # Public. Adds a prelisten callback hook to this robot.
+  #
+  #   cb  - A callback function which accepts a Hook object.
+  #
+  # See also Hook
+  # Returns nothing
+  prelisten: (cb) ->
+    @hooks['prelisten'] ||= []
+    @hooks['prelisten'].push cb
+
+  # Protected. For use by Listener to run prelisten callbacks after a match
+  # is found.
+  #
+  # See also Hook
+  # Returns nothing
+  runPrelistenHooks: (listener, response) ->
+    done = ->
+      listener.callback(response) unless response.envelope.message.done
+    @runHooks 'prelisten', done, response.envelope.message, response, listener
 
 module.exports = Robot

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -575,4 +575,24 @@ class Robot
       listener.callback(response) unless response.envelope.message.done
     @runHooks 'prelisten', done, response.envelope.message, response, listener
 
+  # Public. Adds a prereply callback hook to this robot.
+  #
+  #   cb  - A callback function which accepts a Hook object.
+  #
+  # See also Hook
+  # Returns nothing
+  prereply: (cb) ->
+    @hooks['prereply'] ||= []
+    @hooks['prereply'].push cb
+
+  # Protected. For use by Response to run hooks before replying.
+  #
+  # TODO: we should have a listener available here, but there's no way to get
+  # to it. Responses belong to listeners but don't have a way to get to them,
+  # and we should change that API.
+  runPrereplyHooks: (response, string, cb) ->
+    done = ->
+      cb(response.envelope, string)
+    @runHooks 'prereply', done, response.envelope.message, response, response.listener, string
+
 module.exports = Robot

--- a/test/listener_test.coffee
+++ b/test/listener_test.coffee
@@ -17,6 +17,8 @@ describe 'Listener', ->
     @robot =
       # Why is this part of the Robot object??
       Response: Response
+      runPrelistenHooks: (listener, response) ->
+        listener.callback(response)
 
     # Test user
     @user = new User

--- a/test/listener_test.coffee
+++ b/test/listener_test.coffee
@@ -76,7 +76,7 @@ describe 'Listener', ->
           result = testListener.call testMessage
 
           expect(result).to.be.ok
-          
+
 
         it 'calls the listener callback with a Response that wraps the Message', (done) ->
           testMatcher = sinon.stub().returns(true)
@@ -119,21 +119,21 @@ describe 'Listener', ->
           testMessage = new TextMessage(@user, 'test')
           testMessage.match = sinon.stub().returns(true)
           testRegex = /test/
- 
+
           testListener = new TextListener(@robot, testRegex, callback)
           result = testListener.matcher(testMessage)
- 
+
           expect(result).to.be.ok
           expect(testMessage.match).to.have.been.calledWith(testRegex)
- 
+
         it 'does not match EnterMessages', ->
           callback = sinon.spy()
           testMessage = new EnterMessage(@user)
           testMessage.match = sinon.stub().returns(true)
           testRegex = /test/
- 
+
           testListener = new TextListener(@robot, testRegex, callback)
           result = testListener.matcher(testMessage)
- 
+
           expect(result).to.not.be.ok
           expect(testMessage.match).to.not.have.been.called

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -232,7 +232,7 @@ describe 'Robot', ->
       listenerCallback = sinon.spy()
       @robot.hear /^message123$/, listenerCallback
       @robot.prereceive (hook) ->
-        hook.done()
+        hook.finish()
       @robot.receive testMessage
       expect(listenerCallback).to.not.have.been.called
       done()


### PR DESCRIPTION
Hooks

This is a work-in-progress. I'm opening it early, because there's several parts I'd like feedback on.

This is inspired heavily by @michaelansel's work over in https://github.com/github/hubot/pull/803. We have been abusing `robot.respond /.*/` quite a bit in order to accomplish similar goals, and that pull was eye-opening. This pull does not include an equivalent of the listener metadata from that pull, because that pull does it so elegantly it does not seem worthwhile to revisit. We should get that into master no matter what.

The middleware itself, however, was a little uncomfortable for a few of our use cases. I played around with it and implemented a few things and came up with these issues:

 * They only apply to one phase of a message, "when a listener has matched." I found distinct use cases for at least 3 places (read on).
 * The name 'middleware' has a lot of context from its use in e.g. express, but these do a different thing. They don't have access to responses, for example, and an incoming message can create several responses. It's a hook, not a middleware.
 * It makes listeners async. This complicates testing and would be breaking the API enough that I think it would require calling it 3.0.
 * It added a dependency, and I always want to examine that closely.

This pull adds support for 3 hooks: `prereceive`, `prelisten`, and `prereply`. They run before any listeners have executed, before an individual listener executes, and before any message is sent, respectively.

An example of a `prereceive` hook that blacklists a room but for certain users:

```coffeescript
  robot.prereceive (hook) ->
    if blacklistedRoom(hook.message) && !whitelistedUser(hook.message)
      if hook.message.text.match(/^(\/|hubot)/) # if the message starts with / or 'hubot'
        hook.response.reply "I'm sorry, but I'm configured to ignore commands from this room."
      # But ignore everything, even hear commands.
      hook.finish()
```

An example of a `prelisten` hook, taken from #803. It assumes the listener middleware, which is not in this pull:

```coffeescript
 # node-statsd like interface
  stats =
    increment: (key) ->
      console.log "#{key}:1|c"
      # noop
robot.prelisten (hook) ->
    listenerId = hook.listener.options?.id
    if listenerId?
      stats.increment "hubot.listeners.total.#{listenerId}"
      if hook.response.message.user?.name?
        stats.increment "hubot.listeners.by_user.#{hook.response.message.user.name}.#{listenerId}"
      if hook.response.message.user?.room?
        stats.increment "hubot.listeners.by_room.#{hook.response.message.user.room}.#{listenerId}"
```

An example of a `prereply` hook. This prevents sending a message that matches `/passwords/`:
```coffeescript
robot.prereply (hook) ->
  if hook.reply.text.match(/passwords/)
    hook.finish()
```

And this changes the outgoing message:
```coffeescript
robot.prereply (hook) ->
  if hook.reply.text.match(/passwords/)
    hook.reply.text = "Sorry meatbag, no passwords."
```

I am pretty happy with the hook API as used, but I still need to do some more testing. I'm very interested in feedback, though.

I'm less happy with what happened in the guts. There are a few cases where things could be cleaned up internally if we refactored a few things. For example, `Response`s don't know about their `Listener`s, so a `prereceive` hook constructor needs a response, likewise a `prelistener` and its `Listener`. So the Hook API needs to handle both, but if responses had an when a smarter API might let it handle them a little more elegantly. If we like this direction, this pull would get a bit bigger as I did some reworking internally.

cc @technicalpickles 