### PR TITLE
Fix ambiguous respond regex when robot has alias substring of full name.

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -100,8 +100,9 @@ class Robot
 
     if @alias
       alias = @alias.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+      [a,b] = if name.length > alias.length then [name,alias] else [alias,name]
       newRegex = new RegExp(
-        "^\\s*[@]?(?:#{alias}[:,]?|#{name}[:,]?)\\s*(?:#{pattern})"
+        "^\\s*[@]?(?:#{a}[:,]?|#{b}[:,]?)\\s*(?:#{pattern})"
         modifiers
       )
     else


### PR DESCRIPTION
This pull request fixes a rare bug with respond regex.

When hubot is started with an alias that is a substring of the robot's name weird things happen. Messages addressing the robot via his name can get matched by alias and the remaining chars from the name are being appended to the pattern. That breaks some hubot scripts.

For example the plugin hubot-auth has the following respond regex:
`robot.respond /@?(.+) ha(s|ve) (["'\w: -_]+) role/i, (msg) ->`
So if we start hubot like this:
 `./bin/hubot --name william --alias will`
and try to give John a developer role
```
william> william john has developer role
Shell: iam john does not exist
william>
```
we will get surprised that Hubot can't find John because it looks for "iam John" where "iam" is a left-over from the robot name.