### PR TITLE
Make bin/hubot Warn about unknown options

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -63,6 +63,9 @@ Parser.on "config-check", (opt) ->
 Parser.on "version", (opt, value) ->
   Options.version = true
 
+Parser.on (opt, value) ->
+  console.warn "Unknown option: #{opt}"
+
 Parser.parse process.argv
 
 unless process.platform is "win32"


### PR DESCRIPTION
Previously the bin/hubot script would silently ignore options it was passed that it didn't know about. So the following would start hubot:

    hubot --adaptor something

but wouldn't load the specified adapter as *--adaptor* not *--adapter* was passed as an option. There was no feedback to indicate that the option was unknown so a small mistake like this could lead to some frustrating debugging.

This changes bin/hubot to log a warning to the console if an unknown option is specified.

This could be more strict and stop hubot from starting at all if an unknown option has been passed, but that has the potential to break existing installations.