### PR TITLE
Update scripting docs for crafting post requests

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -161,6 +161,7 @@ A post looks like:
     foo: 'bar'
   })
   robot.http("https://midnight-train")
+    .header('Content-Type', 'application/json')
     .post(data) (err, res, body) ->
       # your code here
 ```


### PR DESCRIPTION
When sending post data via JSON, not all servers will properly parse this by default. Explicitly providing the Content-Type header is more robust.