### PR TITLE
Fix error message about deprecation in executing 'hubot -c'

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -73,6 +73,7 @@ if Options.create
   console.error "'hubot --create' is deprecated. Use the yeoman generator instead:"
   console.error "    npm install -g yo generator-hubot"
   console.error "    mkdir -p #{Options.path}"
+  console.error "    cd #{Options.path}"
   console.error "    yo hubot"
   console.error "See https://github.com/github/hubot/blob/master/docs/README.md for more details on getting started."
   process.exit 1


### PR DESCRIPTION
According to master's hubot/docs/index.md

> % mkdir myhubot
> % cd myhubot
> % yo hubot
