### PR TITLE
Link to modern hubot-scripts organization

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -21,7 +21,7 @@ To use community scripts, place the name of the script in the `hubot-scripts.jso
 ["redis-brain.coffee", "shipit.coffee", "whatis.coffee", "<new-script-name>.coffee"]
 ```
 
-(Please check the [script catalog](http://hubot-script-catalog.herokuapp.com) and the [hubot-scripts repo](https://github.com/github/hubot-scripts/tree/master/src/scripts) for scripts carefully crafted for you by lots of nice folks)
+(Please check the [script catalog](http://hubot-script-catalog.herokuapp.com) and the [hubot-scripts organization](https://github.com/hubot-scripts) for scripts carefully crafted for you by lots of nice folks)
 
 ### NPM Packages
 


### PR DESCRIPTION
Since both of these links end up at https://github.com/github/hubot-scripts, let's change the second one to point to https://github.com/hubot-scripts since those aren't linked right now, and that's where the newer scripts are.