### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,7 @@
     "bot"
   ],
   "description": "A simple helpful robot for your Company",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/github/hubot/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/github/hubot.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/