### PR TITLE
Fix broken link in adapters.md

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -47,4 +47,4 @@ to have yours added to the list:
 
 ## Writing Your Own Adapter
 
-Interested in adding your own adapter? Check out our documentation for [developing adapters](/docs/adapters/development/)
+Interested in adding your own adapter? Check out our documentation for [developing adapters](/docs/adapters/development.md)


### PR DESCRIPTION
The documentation link at the end of the file is broken. Points to development as a directory instead of development.md file. Pull corrects this.