### PR TITLE
Update output of help to match latest version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,33 +59,26 @@ is mostly useful for development. Make note of  `Hubot>`; this is the name your 
 `respond` to with commands. For example, to list available commands:
 
     % bin/hubot
-    Hubot> hubot: help
-    hubot <keyword> tweet - Returns a link to a tweet about <keyword>
-    hubot <user> is a badass guitarist - assign a role to a user
-    hubot <user> is not a badass guitarist - remove a role from a user
+    hubot> hubot help
+    hubot adapter - Reply with the adapter
     hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
-    hubot convert me <expression> to <units> - Convert expression to given units.
-    hubot die - End hubot process
     hubot echo <text> - Reply back with <text>
-    hubot fake event <event> - Triggers the <event> event for debugging reasons
-    hubot help - Displays all of the help commands that Hubot knows about.
+    hubot help - Displays all of the help commands that hubot knows about.
     hubot help <query> - Displays all help commands that match <query>.
     hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
     hubot map me <query> - Returns a map view of the area returned by `query`.
     hubot mustache me <query> - Searches Google Images for the specified query and mustaches it.
     hubot mustache me <url> - Adds a mustache to the specified URL.
     hubot ping - Reply with pong
-    hubot show storage - Display the contents that are persisted in the brain
-    hubot show users - Display all users that hubot knows about
+    hubot pronounce <phrase> in <language> - Provides pronounciation of <phrase> (<language> is optional)
+    hubot pug bomb N - get N pugs
+    hubot pug me - Receive a pug
     hubot the rules - Make sure hubot still knows the rules.
     hubot time - Reply with current time
     hubot translate me <phrase> - Searches for a translation for the <phrase> and then prints that bad boy out.
     hubot translate me from <source> into <target> <phrase> - Translates <phrase> from <source> into <target>. Both <source> and <target> are optional
-    hubot who is <user> - see what roles a user has
     hubot youtube me <query> - Searches YouTube for the query and returns the video embed link.
-    hubot pug bomb N - get N pugs
-    hubot pug me - Receive a pug
-    hubot ship it - Display a motivation squirrel
+    ship it - Display a motivation squirrel
 
 You almost definitely will want to change your hubot's name to add character. bin/hubot takes a `--name`:
 


### PR DESCRIPTION
Just a minor doc update to make the ouptut of `hubot help` match the latest version since some scripts have been removed.