### PR TITLE
Prepare for 2.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ v2.13.1
 =======
 
 * Fix documentation when running `hubot -c` to suggest correct usage of generator https://github.com/github/hubot/pull/938
-* Fix respond listeners matching when robot alias is a substring of robot alias https://github.com/github/hubot/pull/927
+* Fix respond listeners matching when robot alias is a substring of robot name https://github.com/github/hubot/pull/927
 * Update bin/hubot to log a warning if called with non-existent options https://github.com/github/hubot/pull/931
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v2.13.1
+=======
+
+* Fix documentation when running `hubot -c` to suggest correct usage of generator https://github.com/github/hubot/pull/938
+* Fix respond listeners matching when robot alias is a substring of robot alias https://github.com/github/hubot/pull/927
+* Update bin/hubot to log a warning if called with non-existent options https://github.com/github/hubot/pull/931
+
+
 v2.13.0
 =======
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "author": "hubot",
   "keywords": [
     "github",


### PR DESCRIPTION
* Fix documentation when running `hubot -c` to suggest correct usage of generator  cc @ta1kt0me  https://github.com/github/hubot/pull/938
* Fix respond listeners matching when robot alias is a substring of robot alias cc @sdimkov   https://github.com/github/hubot/pull/927 https://github.com/github/hubot/pull/967
* Update bin/hubot to log a warning if called with non-existent options cc @petedmarsh https://github.com/github/hubot/pull/931

cc @github/open-source-hubot-maintainers 