### PR TITLE
git-ignore .node-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .hubot_history
+.node-version


### PR DESCRIPTION
There is no .npmignore so npm will fallback to .gitignore to determine
which files to omit from the package.