### PR TITLE
Prepare for v2.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+v2.13.2
+=======
+
+* Minor documentation updates
+* Add Robot.respondPattern private to improve testability https://github.com/github/hubot/pull/975
+* Ignore .node-version so it isn't included in releases https://github.com/github/hubot/pull/980
+
 v2.13.1
 =======
 
 * Fix documentation when running `hubot -c` to suggest correct usage of generator https://github.com/github/hubot/pull/938
 * Fix respond listeners matching when robot alias is a substring of robot name https://github.com/github/hubot/pull/927
 * Update bin/hubot to log a warning if called with non-existent options https://github.com/github/hubot/pull/931
-
 
 v2.13.0
 =======

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "author": "hubot",
   "keywords": [
     "github",


### PR DESCRIPTION
* Minor documentation updates #955 #974 #973 @praseodym @bhuga @Sing-Li 
* Add Robot.respondPattern private to improve testability https://github.com/github/hubot/pull/975 @michaelansel
* Ignore .node-version so it isn't included in releases https://github.com/github/hubot/pull/980 @jasonkarns 

cc @github/open-source-hubot-maintainers

Changes: https://github.com/github/hubot/compare/v2.13.1...release-v2.13.2