### PR TITLE
Add windows and azure documentation

### DIFF
--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -1,0 +1,81 @@
+---
+permalink: /docs/deploying/azure/index.html
+layout: docs
+---
+
+If you've been following along with [Getting Started](../README.md), it's time to deploy so you can use it beyond just your local machine.
+[Azure](http://http://azure.microsoft.com/) is a somewhat easy and probably unsupported way to deploy hubot.
+
+You will need to install the azure-cli via npm after you have follow the initial instructions for your hubot.
+
+    % npm install -g azure-cli
+
+Inside your new hubot directory, make sure you've created a git repository, and that your work is committed:
+
+    % git init
+    % git add .
+    % git commit -m "Initial commit"
+
+Then create a github repository for your hubot. This is where zzure will pull your code from instead of needing to deploy directly from your dev machine to azure.
+
+    % git remote add origin _your github repo_
+	% git push -u origin master
+	
+Create a linked azure website. In azure, create a website and select integrated source control. When it asks "where is your source control" select GitHub and link this website to your git repo that you created in the previous step. If you have downloaded the azure powershell modules, you can also do this via powershell.
+
+    % $creds = Get-Credential
+	% new-azurewebsite mynewhubot -github -hithubrepository yourgithubaccount/yourhubotreponame -githubcredentials $creds
+	
+Once you have done this, azure will deploy your site on the next commit and push you do to github. Your hubot won't run quite right yet, though. Next, you need to configure the deployment to tell azure how to run hubot.
+	
+First, run the follow command to add _deploy.cmd_ to your hubot directory. This is the file that azure uses to know how to deploy your node application.
+
+    % azure site deploymentscript --node
+	
+Then, edit this file and look for the sections that give you steps 1, 2 and 3. You're going to add a 4th step:
+
+    :: 4. Create Hubot file with a coffee extension
+    copy /Y “%DEPLOYMENT_TARGET%\node_modules\hubot\bin\hubot” “%DEPLOYMENT_TARGET%\node_modules\hubot\bin\hubot.coffee”
+
+Now, create a new file in the base directory of Hubot called "server.js" and put these two lines into it:
+
+    require('coffee-script/register');
+	module.exports = require('hubot/bin/hubot.coffee');
+	
+Save this file. Then open up external-scripts.json and remove the following two lines, as these two bits aren't compatible with azure.
+
+    "hubot-heroku-keepalive",
+	"hubot-redit-brain",
+	
+Save this file then install coffee-script as a requirement to your local hubot. Azure requires this to run hubot properly.
+
+    % npm install coffee-script --save
+
+Finally you will need to add the environment variables to the website to make sure it runs properly. You can either do it through the GUI, under configuration or you can use the azure powershell command line, as follows (example is showing slack as an adapter and mynewhubot as the website name).
+
+    % $settings = New-Object Hashtable
+	% $settings["HUBOT_ADAPTER"] = "Slack"
+	% $settings["HUBOT_SLACK_TOKEN"] = "yourslackapikey"
+	% Set-AzureWebsite -AppSettings $settings mynewhubot
+	
+Commit your changes in git and push to github and azure will automatically pick up the changes and deploy them to your website.
+
+    % git commit -m "Add azure settings for hubot"
+	% git push
+	
+Hubot now works just fine but doesn't have a brain. To add a brain that works with azure, you will need to create an azure storage account and account key. Then you can do the following in your base hubot directory.
+
+    % npm install hubot-azure-scripts --save
+
+Then add the following line in external-scripts.json in the list with the other external scripts
+
+    "hubot-azure-scripts/brain/azure-blob-brain"
+	
+Finally, add two more environment variables to your website. You can do this either via the gui or powershell commands.
+
+    % $settings = New-Object Hashtable
+	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCOUNT"] = "your azure storage account"
+	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCESS_KEY"] = "your azure storage account key"
+	% Set-AzureWebsite -AppSettings $settings mynewhubot
+	
+Now any scripts that require a brain will function. You should look up other scripts or write your own by looking at the [documentation](https://hubot.github.com/docs/scripting/). All of the normal scripts for hubot are compatible with hosting hubot on azure.

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -16,19 +16,19 @@ Inside your new hubot directory, make sure you've created a git repository, and 
     % git add .
     % git commit -m "Initial commit"
 
-Then create a github repository for your hubot. This is where zzure will pull your code from instead of needing to deploy directly from your dev machine to azure.
+Then create a GitHub repository for your hubot. This is where zzure will pull your code from instead of needing to deploy directly from your dev machine to Azure.
 
-    % git remote add origin _your github repo_
+    % git remote add origin _your GitHub repo_
 	% git push -u origin master
 	
-Create a linked azure website. In azure, create a website and select integrated source control. When it asks "where is your source control" select GitHub and link this website to your git repo that you created in the previous step. If you have downloaded the azure powershell modules, you can also do this via powershell.
+Create a linked Azure website. In Azure, create a website and select integrated source control. When it asks "where is your source control" select GitHub and link this website to your git repo that you created in the previous step. If you have downloaded the Azure PowerShell modules, you can also do this via PowerShell.
 
     % $creds = Get-Credential
-	% new-azurewebsite mynewhubot -github -hithubrepository yourgithubaccount/yourhubotreponame -githubcredentials $creds
+	% New-AzureWebsite mynewhubot -github -githubrepository yourgithubaccount/yourhubotreponame -githubcredentials $creds
 	
-Once you have done this, azure will deploy your site on the next commit and push you do to github. Your hubot won't run quite right yet, though. Next, you need to configure the deployment to tell azure how to run hubot.
+Once you have done this, Azure will deploy your site any time you commit and push to GitHub. Your hubot won't run quite right yet, though. Next, you need to configure the deployment to tell Azure how to run hubot.
 	
-First, run the follow command to add _deploy.cmd_ to your hubot directory. This is the file that azure uses to know how to deploy your node application.
+First, run the follow command to add `deploy.cmd` to your hubot directory. This is the file that Azure uses to know how to deploy your node application.
 
     % azure site deploymentscript --node
 	
@@ -37,12 +37,12 @@ Then, edit this file and look for the sections that give you steps 1, 2 and 3. Y
     :: 4. Create Hubot file with a coffee extension
     copy /Y “%DEPLOYMENT_TARGET%\node_modules\hubot\bin\hubot” “%DEPLOYMENT_TARGET%\node_modules\hubot\bin\hubot.coffee”
 
-Now, create a new file in the base directory of Hubot called "server.js" and put these two lines into it:
+Now, create a new file in the base directory of hubot called `server.js` and put these two lines into it:
 
     require('coffee-script/register');
 	module.exports = require('hubot/bin/hubot.coffee');
 	
-Save this file. Then open up external-scripts.json and remove the following two lines, as these two bits aren't compatible with azure.
+Save this file. Then open up `external-scripts.json` and remove the following two lines, as these two bits aren't compatible with Azure.
 
     "hubot-heroku-keepalive",
 	"hubot-redit-brain",
@@ -51,31 +51,31 @@ Save this file then install coffee-script as a requirement to your local hubot. 
 
     % npm install coffee-script --save
 
-Finally you will need to add the environment variables to the website to make sure it runs properly. You can either do it through the GUI, under configuration or you can use the azure powershell command line, as follows (example is showing slack as an adapter and mynewhubot as the website name).
+Finally you will need to add the environment variables to the website to make sure it runs properly. You can either do it through the GUI (under configuration) or you can use the Azure PowerShell command line, as follows (example is showing slack as an adapter and mynewhubot as the website name).
 
     % $settings = New-Object Hashtable
 	% $settings["HUBOT_ADAPTER"] = "Slack"
 	% $settings["HUBOT_SLACK_TOKEN"] = "yourslackapikey"
 	% Set-AzureWebsite -AppSettings $settings mynewhubot
 	
-Commit your changes in git and push to github and azure will automatically pick up the changes and deploy them to your website.
+Commit your changes in git and push to GitHub and Azure will automatically pick up the changes and deploy them to your website.
 
-    % git commit -m "Add azure settings for hubot"
+    % git commit -m "Add Azure settings for hubot"
 	% git push
 	
-Hubot now works just fine but doesn't have a brain. To add a brain that works with azure, you will need to create an azure storage account and account key. Then you can do the following in your base hubot directory.
+Hubot now works just fine but doesn't have a brain. To add a brain that works with Azure, you will need to create an Azure storage account and account key. Then you can do the following in your base hubot directory.
 
     % npm install hubot-azure-scripts --save
 
-Then add the following line in external-scripts.json in the list with the other external scripts
+Then add the following line in `external-scripts.json` in the list with the other external scripts
 
     "hubot-azure-scripts/brain/azure-blob-brain"
 	
-Finally, add two more environment variables to your website. You can do this either via the gui or powershell commands.
+Finally, add two more environment variables to your website. You can do this either via the GUI or the following PowerShell commands.
 
     % $settings = New-Object Hashtable
-	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCOUNT"] = "your azure storage account"
-	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCESS_KEY"] = "your azure storage account key"
+	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCOUNT"] = "your Azure storage account"
+	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCESS_KEY"] = "your Azure storage account key"
 	% Set-AzureWebsite -AppSettings $settings mynewhubot
 	
-Now any scripts that require a brain will function. You should look up other scripts or write your own by looking at the [documentation](https://hubot.github.com/docs/scripting/). All of the normal scripts for hubot are compatible with hosting hubot on azure.
+Now any scripts that require a brain will function. You should look up other scripts or write your own by looking at the [documentation](https://hubot.github.com/docs/scripting/). All of the normal scripts for hubot are compatible with hosting hubot on Azure.

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -4,7 +4,7 @@ layout: docs
 ---
 
 If you've been following along with [Getting Started](../README.md), it's time to deploy so you can use it beyond just your local machine.
-[Azure](http://http://azure.microsoft.com/) is a way to deploy hubot as an alternative to [Heroku](/docs/deploying/heroku.md).
+[Azure](http://azure.microsoft.com/) is a way to deploy hubot as an alternative to [Heroku](/docs/deploying/heroku.md).
 
 You will need to install the azure-cli via npm after you have follow the initial instructions for your hubot.
 

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -4,7 +4,7 @@ layout: docs
 ---
 
 If you've been following along with [Getting Started](../README.md), it's time to deploy so you can use it beyond just your local machine.
-[Azure](http://http://azure.microsoft.com/) is a somewhat easy and probably unsupported way to deploy hubot.
+[Azure](http://http://azure.microsoft.com/) is a way to deploy hubot as an alternative to [Heroku](/docs/deploying/heroku.md).
 
 You will need to install the azure-cli via npm after you have follow the initial instructions for your hubot.
 
@@ -16,22 +16,22 @@ Inside your new hubot directory, make sure you've created a git repository, and 
     % git add .
     % git commit -m "Initial commit"
 
-Then create a GitHub repository for your hubot. This is where zzure will pull your code from instead of needing to deploy directly from your dev machine to Azure.
+Then [create a GitHub repository](https://help.github.com/articles/create-a-repo/) for your hubot. This is where Azure will pull your code from instead of needing to deploy directly from your dev machine to Azure.
 
     % git remote add origin _your GitHub repo_
-	% git push -u origin master
-	
-Create a linked Azure website. In Azure, create a website and select integrated source control. When it asks "where is your source control" select GitHub and link this website to your git repo that you created in the previous step. If you have downloaded the Azure PowerShell modules, you can also do this via PowerShell.
+    % git push -u origin master
+
+Once you have your GitHub repo, create an Azure website linked to your repo. In Azure, create a website and select integrated source control. When it asks "where is your source control" select GitHub and link this website to your git repo that you created in the previous step. If you have downloaded the Azure PowerShell modules, you can also do this via PowerShell.
 
     % $creds = Get-Credential
-	% New-AzureWebsite mynewhubot -github -githubrepository yourgithubaccount/yourhubotreponame -githubcredentials $creds
-	
+    % New-AzureWebsite mynewhubot -github -githubrepository yourgithubaccount/yourhubotreponame -githubcredentials $creds
+
 Once you have done this, Azure will deploy your site any time you commit and push to GitHub. Your hubot won't run quite right yet, though. Next, you need to configure the deployment to tell Azure how to run hubot.
-	
+
 First, run the follow command to add `deploy.cmd` to your hubot directory. This is the file that Azure uses to know how to deploy your node application.
 
     % azure site deploymentscript --node
-	
+
 Then, edit this file and look for the sections that give you steps 1, 2 and 3. You're going to add a 4th step:
 
     :: 4. Create Hubot file with a coffee extension
@@ -40,29 +40,25 @@ Then, edit this file and look for the sections that give you steps 1, 2 and 3. Y
 Now, create a new file in the base directory of hubot called `server.js` and put these two lines into it:
 
     require('coffee-script/register');
-	module.exports = require('hubot/bin/hubot.coffee');
-	
-Save this file. Then open up `external-scripts.json` and remove the following two lines, as these two bits aren't compatible with Azure.
+    module.exports = require('hubot/bin/hubot.coffee');
+
+Save this file. Then open up `external-scripts.json` and remove the following two lines, as these two bits aren't compatible with Azure and then save the file.
 
     "hubot-heroku-keepalive",
-	"hubot-redit-brain",
-	
-Save this file then install coffee-script as a requirement to your local hubot. Azure requires this to run hubot properly.
-
-    % npm install coffee-script --save
+    "hubot-redit-brain",
 
 Finally you will need to add the environment variables to the website to make sure it runs properly. You can either do it through the GUI (under configuration) or you can use the Azure PowerShell command line, as follows (example is showing slack as an adapter and mynewhubot as the website name).
 
     % $settings = New-Object Hashtable
-	% $settings["HUBOT_ADAPTER"] = "Slack"
-	% $settings["HUBOT_SLACK_TOKEN"] = "yourslackapikey"
-	% Set-AzureWebsite -AppSettings $settings mynewhubot
-	
+    % $settings["HUBOT_ADAPTER"] = "Slack"
+    % $settings["HUBOT_SLACK_TOKEN"] = "yourslackapikey"
+    % Set-AzureWebsite -AppSettings $settings mynewhubot
+
 Commit your changes in git and push to GitHub and Azure will automatically pick up the changes and deploy them to your website.
 
     % git commit -m "Add Azure settings for hubot"
-	% git push
-	
+    % git push
+
 Hubot now works just fine but doesn't have a brain. To add a brain that works with Azure, you will need to create an Azure storage account and account key. Then you can do the following in your base hubot directory.
 
     % npm install hubot-azure-scripts --save
@@ -70,12 +66,12 @@ Hubot now works just fine but doesn't have a brain. To add a brain that works wi
 Then add the following line in `external-scripts.json` in the list with the other external scripts
 
     "hubot-azure-scripts/brain/azure-blob-brain"
-	
+
 Finally, add two more environment variables to your website. You can do this either via the GUI or the following PowerShell commands.
 
     % $settings = New-Object Hashtable
-	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCOUNT"] = "your Azure storage account"
-	% $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCESS_KEY"] = "your Azure storage account key"
-	% Set-AzureWebsite -AppSettings $settings mynewhubot
-	
-Now any scripts that require a brain will function. You should look up other scripts or write your own by looking at the [documentation](https://hubot.github.com/docs/scripting/). All of the normal scripts for hubot are compatible with hosting hubot on Azure.
+    % $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCOUNT"] = "your Azure storage account"
+    % $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCESS_KEY"] = "your Azure storage account key"
+    % Set-AzureWebsite -AppSettings $settings mynewhubot
+
+Now any scripts that require a brain will function. You should look up other scripts or write your own by looking at the [documentation](/docs/scripting.md). All of the normal scripts for hubot are compatible with hosting hubot on Azure.

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -5,10 +5,11 @@ layout: docs
 
 Hasn't been fully tested - YMMV
 
-There are 3 primary things to deploying and running hubot on a windows machine:
+There are 4 primary steps to deploying and running hubot on a Windows machine:
 
   * node and npm
   * a way to get source code updated on the server
+  * setting up environment variables for hubot
   * a way to start hubot, start it up if it crashes, and restart it when code
     updates
 
@@ -22,15 +23,15 @@ Your other option is to install directly from [NodeJS](https://nodejs.org/) and 
 
 ## Updating code on the server
 
-To get the code on your server, you can follow the instructions at [Getting Started](https://hubot.github.com/docs/) on your local development machine or directly on the server. If you are building locally, push your hubot to git and clone the repo onto your server. Don't clone the normal [github/hubot repository](http://github.com/github/hubot), make sure you're using the Yo Generator to build your own hubot.
+To get the code on your server, you can follow the instructions at [Getting Started](https://hubot.github.com/docs/) on your local development machine or directly on the server. If you are building locally, push your hubot to GitHub and clone the repo onto your server. Don't clone the normal [github/hubot repository](http://github.com/github/hubot), make sure you're using the Yo Generator to build your own hubot.
 
 ## Setting up environment vars
 
-You will want to set up your hubot environment variables on the server where it will run. You can do this by opening a administrative powershell/command prompt and typing the following:
+You will want to set up your hubot environment variables on the server where it will run. You can do this by opening an administrative PowerShell and typing the following:
 
     [Environment]::SetEnvironmentVariable("HUBOT_ADAPTER", "Campfire", "Machine")
 	
-This is equivelent to going into the system menu -> selecting advanced system settings => environment vars and adding a new system variable called HUBOT_ADAPTER with the value of Campfire.
+This is equivalent to going into the system menu -> selecting advanced system settings -> environment vars and adding a new system variable called HUBOT_ADAPTER with the value of Campfire.
 
 ## Starting, stopping, and restarting hubot
 
@@ -45,7 +46,7 @@ There are a few issues if you call it manually, though.
 * hubot dies, for any reason, and doesn't start again
 * it doesn't start up at boot automatically
 
-To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your Hubot directory. It should contain the following:
+To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. It should contain the following:
 
     Write-Host “Starting Hubot Watcher”
     While (1)
@@ -54,7 +55,7 @@ To fix this, you will want to create a .ps1 file with whatever name makes you ha
         Start-Process powershell -ArgumentList “.\bin\hubot –adapter slack” -wait
 	}
 
-Remember to allow local unsigned powershell scripts if you are using the .ps1 file to run hubot. Run this command in an Administrator Powershell window.
+Remember to allow local unsigned PowerShell scripts if you are using the .ps1 file to run hubot. Run this command in an Administrator PowerShell window.
 
     Set-ExecutionPolicy RemoteSigned
 	

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -5,7 +5,7 @@ layout: docs
 
 Hasn't been fully tested - YMMV
 
-There are 3 primary things to deploying and running hubot:
+There are 3 primary things to deploying and running hubot on a windows machine:
 
   * node and npm
   * a way to get source code updated on the server
@@ -18,21 +18,48 @@ To start, your windows server will need node and npm.
 The best way to do this is with [chocolatey](http://chocolatey.org) using the [nodejs.install](http://chocolatey.org/packages/nodejs.install) package.
 I've found that sometimes the system path variable is not correctly set; ensure you can run node/npm from the command line. If needed set the PATH variable with "setx PATH \"%PATH%;C:\Program Files\nodejs\" "
 
+Your other option is to install directly from [NodeJS](https://nodejs.org/) and run the current download (v0.12.4 as of this documentation). This should set your PATH variables for you.
+
 ## Updating code on the server
 
-The simplest way to update your hubot's code is going to be to have a git
-checkout of your hubot's source code (that you've created during [Getting Started](../README.md), not the [github/hubot repository](http://github.com/github/hubot), and just git pull to get change. This may
-feel a dirty hack, but it works when you are starting out.
+To get the code on your server, you can follow the instructions at [Getting Started](https://hubot.github.com/docs/) on your local development machine or directly on the server. If you are building locally, push your hubot to git and clone the repo onto your server. Don't clone the normal [github/hubot repository](http://github.com/github/hubot), make sure you're using the Yo Generator to build your own hubot.
+
+## Setting up environment vars
+
+You will want to set up your hubot environment variables on the server where it will run. You can do this by opening a administrative powershell/command prompt and typing the following:
+
+    [Environment]::SetEnvironmentVariable("HUBOT_ADAPTER", "Campfire", "Machine")
+	
+This is equivelent to going into the system menu -> selecting advanced system settings => environment vars and adding a new system variable called HUBOT_ADAPTER with the value of Campfire.
 
 ## Starting, stopping, and restarting hubot
 
 Every hubot install has a `bin/hubot` script to handle starting up the hubot.
-You can run this command from your git checkout on the server, but there are some problems you can encounter:
+You can run this command directly from your hubot folder by typing the following:
+
+    .\bin\hubot –adapter campfire
+
+There are a few issues if you call it manually, though.
 
 * you disconnect, and hubot dies
 * hubot dies, for any reason, and doesn't start again
 * it doesn't start up at boot automatically
 
+To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your Hubot directory. It should contain the following:
+
+    Write-Host “Starting Hubot Watcher”
+    While (1)
+    {
+        Write-Host “Starting Hubot
+        Start-Process powershell -ArgumentList “.\bin\hubot –adapter slack” -wait
+	}
+
+Remember to allow local unsigned powershell scripts if you are using the .ps1 file to run hubot. Run this command in an Administrator Powershell window.
+
+    Set-ExecutionPolicy RemoteSigned
+	
+You can set this .ps1 as scheduled task on boot if you like or some other way to start your process. 
+	
 ## Expanding the documentation
 
 Not yet fleshed out. [Help contribute by submitting a pull request, please?](https://github.com/github/hubot/pull/new/master)

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -47,11 +47,11 @@ There are a few issues if you call it manually, though.
 
 To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. There is a copy of this file in the `examples` directory. It should contain the following:
 
-    Write-Host “Starting Hubot Watcher”
+    Write-Host "Starting Hubot Watcher"
     While (1)
     {
-        Write-Host “Starting Hubot
-        Start-Process powershell -ArgumentList “.\bin\hubot –adapter slack” -wait
+        Write-Host "Starting Hubot"
+        Start-Process powershell -ArgumentList ".\bin\hubot –adapter slack" -wait
     }
 
 Remember to allow local unsigned PowerShell scripts if you are using the .ps1 file to run hubot. Run this command in an Administrator PowerShell window.

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -10,8 +10,7 @@ There are 4 primary steps to deploying and running hubot on a Windows machine:
   * node and npm
   * a way to get source code updated on the server
   * setting up environment variables for hubot
-  * a way to start hubot, start it up if it crashes, and restart it when code
-    updates
+  * a way to start hubot, start it up if it crashes, and restart it when code updates
 
 ## node and npm
 
@@ -23,14 +22,14 @@ Your other option is to install directly from [NodeJS](https://nodejs.org/) and 
 
 ## Updating code on the server
 
-To get the code on your server, you can follow the instructions at [Getting Started](https://hubot.github.com/docs/) on your local development machine or directly on the server. If you are building locally, push your hubot to GitHub and clone the repo onto your server. Don't clone the normal [github/hubot repository](http://github.com/github/hubot), make sure you're using the Yo Generator to build your own hubot.
+To get the code on your server, you can follow the instructions at [Getting Started](/docs/index.md) on your local development machine or directly on the server. If you are building locally, push your hubot to GitHub and clone the repo onto your server. Don't clone the normal [github/hubot repository](http://github.com/github/hubot), make sure you're using the Yo Generator to build your own hubot.
 
 ## Setting up environment vars
 
 You will want to set up your hubot environment variables on the server where it will run. You can do this by opening an administrative PowerShell and typing the following:
 
     [Environment]::SetEnvironmentVariable("HUBOT_ADAPTER", "Campfire", "Machine")
-	
+
 This is equivalent to going into the system menu -> selecting advanced system settings -> environment vars and adding a new system variable called HUBOT_ADAPTER with the value of Campfire.
 
 ## Starting, stopping, and restarting hubot
@@ -46,22 +45,21 @@ There are a few issues if you call it manually, though.
 * hubot dies, for any reason, and doesn't start again
 * it doesn't start up at boot automatically
 
-To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. It should contain the following:
+To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. There is a copy of this file in the `examples` directory. It should contain the following:
 
     Write-Host “Starting Hubot Watcher”
     While (1)
     {
         Write-Host “Starting Hubot
         Start-Process powershell -ArgumentList “.\bin\hubot –adapter slack” -wait
-	}
+    }
 
 Remember to allow local unsigned PowerShell scripts if you are using the .ps1 file to run hubot. Run this command in an Administrator PowerShell window.
 
     Set-ExecutionPolicy RemoteSigned
-	
+
 You can set this .ps1 as scheduled task on boot if you like or some other way to start your process. 
 
-	
 ## Expanding the documentation
 
 Not yet fleshed out. [Help contribute by submitting a pull request, please?](https://github.com/github/hubot/pull/new/master)

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -45,7 +45,7 @@ There are a few issues if you call it manually, though.
 * hubot dies, for any reason, and doesn't start again
 * it doesn't start up at boot automatically
 
-To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. There is a copy of this file in the `examples` directory. It should contain the following:
+To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. There is a copy of this file in the `examples` directory [here](/examples/hubot-start.ps1). It should contain the following:
 
     Write-Host "Starting Hubot Watcher"
     While (1)

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -54,19 +54,12 @@ To fix this, you will want to create a .ps1 file with whatever name makes you ha
         Start-Process powershell -ArgumentList “.\bin\hubot –adapter slack” -wait
 	}
 
-<<<<<<< HEAD
 Remember to allow local unsigned powershell scripts if you are using the .ps1 file to run hubot. Run this command in an Administrator Powershell window.
 
     Set-ExecutionPolicy RemoteSigned
 	
 You can set this .ps1 as scheduled task on boot if you like or some other way to start your process. 
-=======
-Remember to allow local unsigned powershell scripts if you are using this. Run this in an Administrator Powershell window.
 
-    Set-ExecutionPolicy RemoteSigned
-	
-You can set this as scheduled task on boot if you like or some other way to start your process. 
->>>>>>> eb9f78d90095836adfa6501cc36ca6666c5dffab
 	
 ## Expanding the documentation
 

--- a/examples/hubot-start.ps1
+++ b/examples/hubot-start.ps1
@@ -1,0 +1,12 @@
+#Hubot PowerShell Start Script
+#Invoke from the PowerShell prompt or start via automated tools 
+
+$HubotPath = "drive:\path\to\hubot"
+$HubotAdapter = "Hubot adapter"
+
+Write-Host "Starting Hubot Watcher"
+While (1)
+{
+    Write-Host "Starting Hubot"
+    Start-Process powershell -ArgumentList "$HubotPath\bin\hubot –adapter $HubotAdapter" -wait
+}


### PR DESCRIPTION
This is documentation for deploying Hubot on windows and onto azure. I'm not 100% sure I created the link to the azure documentation correctly.