### PR TITLE
Add Robot.listen

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -77,3 +77,34 @@ module.export = (robot) ->
   robot.globalHttpOptions.httpAgent  = proxy('http://my-proxy-server.internal', false)
   robot.globalHttpOptions.httpsAgent = proxy('http://my-proxy-server.internal', true)
 ```
+
+## Dynamic matching of messages
+
+In some situations, you want to dynamically match different messages (e.g. factoids, JIRA projects). Rather than defining an overly broad regular expression that always matches, you can tell Hubot to only match when certain conditions are met.
+
+In a simple robot, this isn't much different from just putting the conditions in the Listener callback, but it makes a big difference when you are dealing with middleware: with the basic model, middleware will be executed for every match of the generic regex. With the dynamic matching model, middleware will only be executed when the dynamic conditions are matched.
+
+For example, the factoid lookup command could be reimplemented as:
+
+```coffeescript
+module.exports = (robot) ->
+  # Dynamically populated list of factoids
+  facts =
+    fact1: 'stuff'
+    fact2: 'other stuff'
+
+  robot.listen(
+    # Matcher
+    (message) ->
+      match = message.match(/^~(.*)$/)
+      # Only match if there is a matching factoid
+      if match and match[1] in facts
+        match[1]
+      else
+        false
+    # Callback
+    (response) ->
+      fact = response.match
+      res.reply "#{fact} is #{facts[fact]}"
+  )
+```

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -84,7 +84,7 @@ In some situations, you want to dynamically match different messages (e.g. facto
 
 In a simple robot, this isn't much different from just putting the conditions in the Listener callback, but it makes a big difference when you are dealing with middleware: with the basic model, middleware will be executed for every match of the generic regex. With the dynamic matching model, middleware will only be executed when the dynamic conditions are matched.
 
-For example, the factoid lookup command could be reimplemented as:
+For example, the [factoid lookup command](https://github.com/github/hubot-scripts/blob/bd810f99f9394818a9dcc2ea3729427e4101b96d/src/scripts/factoid.coffee#L95-L99) could be reimplemented as:
 
 ```coffeescript
 module.exports = (robot) ->

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -264,14 +264,17 @@ module.exports = (robot) ->
 
 While the above helpers cover most of the functionality the average user needs (hear, respond, enter, leave, topic), sometimes you would like to have very specialized matching logic for listeners. If so, you can use `listen` to specify a custom match function instead of a regular expression.
 
+The match function must return a truthy value if the listener callback should be executed. The truthy return value of the match function is then passed to the callback as response.match.
+
 ```coffeescript
 module.exports = (robot) ->
   robot.listen(
-    (message) ->
-      # This function must return a truthy value if the listener callback should be executed.
-      # The return value of the match function is passed to the callback as response.match
-    (response) ->
-      # This is the standard listener callback
+    (message) -> # Match function
+      # Occassionally respond to things that Steve says
+      message.user.name is "Steve" and Math.random() > 0.8
+    (response) -> # Standard listener callback
+      # Let Steve know how happy you are that he exists
+      response.reply "HI STEVE! YOU'RE MY BEST FRIEND!"
   )
 ```
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -274,7 +274,7 @@ module.exports = (robot) ->
       message.user.name is "Steve" and Math.random() > 0.8
     (response) -> # Standard listener callback
       # Let Steve know how happy you are that he exists
-      response.reply "HI STEVE! YOU'RE MY BEST FRIEND!"
+      response.reply "HI STEVE! YOU'RE MY BEST FRIEND! (but only like #{response.match * 100}% of the time)"
   )
 ```
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -260,6 +260,21 @@ module.exports = (robot) ->
     res.send res.random leaveReplies
 ```
 
+## Custom Listeners
+
+While the above helpers cover most of the functionality the average user needs (hear, respond, enter, leave, topic), sometimes you would like to have very specialized matching logic for listeners. If so, you can use `listen` to specify a custom match function instead of a regular expression.
+
+```coffeescript
+module.exports = (robot) ->
+  robot.listen(
+    (message) ->
+      # This function must return a truthy value if the listener callback should be executed.
+      # The return value of the match function is passed to the callback as response.match
+    (response) ->
+      # This is the standard listener callback
+  )
+```
+
 ## Environment variables
 
 Hubot can access the environment he's running in, just like any other node program, using [`process.env`](http://nodejs.org/api/process.html#process_process_env). This can be used to configure how scripts are run, with the convention being to use the `HUBOT_` prefix.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -275,6 +275,8 @@ module.exports = (robot) ->
   )
 ```
 
+See [the design patterns document](patterns.md) for examples of complex matchers.
+
 ## Environment variables
 
 Hubot can access the environment he's running in, just like any other node program, using [`process.env`](http://nodejs.org/api/process.html#process_process_env). This can be used to configure how scripts are run, with the convention being to use the `HUBOT_` prefix.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -72,7 +72,8 @@ class Robot
   # callback
   #
   # matcher  - A Function that determines whether to call the callback.
-  #            Expected to return a boolean.
+  #            Expected to return a truthy value if the callback should be
+  #            executed.
   # options  - An Object of additional parameters keyed on extension name
   #            (optional).
   # callback - A Function that is called with a Response object if the

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -68,6 +68,20 @@ class Robot
       @emit 'error', err
     process.on 'uncaughtException', @onUncaughtException
 
+  # Public: Adds a custom Listener with the provided matcher, options, and
+  # callback
+  #
+  # matcher  - A Function that determines whether to call the callback.
+  #            Expected to return a boolean.
+  # options  - An Object of additional parameters keyed on extension name
+  #            (optional).
+  # callback - A Function that is called with a Response object if the
+  #            matcher function returns true.
+  #
+  # Returns nothing.
+  listen: (matcher, options, callback) ->
+    @listeners.push new Listener(@, matcher, options, callback)
+
   # Public: Adds a Listener that attempts to match incoming messages based on
   # a Regex.
   #
@@ -91,7 +105,7 @@ class Robot
   #
   # Returns nothing.
   respond: (regex, options, callback) ->
-    @listeners.push new TextListener(@, @respondPattern(regex), options, callback)
+    @hear(@respondPattern(regex), options, callback)
 
   # Private: Build a regular expression that matches messages addressed
   # directly to the robot
@@ -135,10 +149,9 @@ class Robot
   #
   # Returns nothing.
   enter: (options, callback) ->
-    @listeners.push new Listener(
-      @,
-      ((msg) -> msg instanceof EnterMessage),
-      options,
+    @listen(
+      ((msg) -> msg instanceof EnterMessage)
+      options
       callback
     )
 
@@ -150,10 +163,9 @@ class Robot
   #
   # Returns nothing.
   leave: (options, callback) ->
-    @listeners.push new Listener(
-      @,
-      ((msg) -> msg instanceof LeaveMessage),
-      options,
+    @listen(
+      ((msg) -> msg instanceof LeaveMessage)
+      options
       callback
     )
 
@@ -165,10 +177,9 @@ class Robot
   #
   # Returns nothing.
   topic: (options, callback) ->
-    @listeners.push new Listener(
-      @,
-      ((msg) -> msg instanceof TopicMessage),
-      options,
+    @listen(
+      ((msg) -> msg instanceof TopicMessage)
+      options
       callback
     )
 
@@ -210,10 +221,9 @@ class Robot
       callback = options
       options = {}
 
-    @listeners.push new Listener(
-      @,
-      ((msg) -> msg instanceof CatchAllMessage),
-      options,
+    @listen(
+      ((msg) -> msg instanceof CatchAllMessage)
+      options
       ((msg) -> msg.message = msg.message.message; callback msg)
     )
 

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -135,6 +135,12 @@ describe 'Robot', ->
         match2 = testMessage2.match(pattern)[1]
         expect(match2).to.equal('message123')
 
+    describe '#listen', ->
+      it 'registers a new listener', ->
+        expect(@robot.listeners).to.have.length(0)
+        @robot.hear /.*/, ->
+        expect(@robot.listeners).to.have.length(1)
+
     describe '#hear', ->
       it 'registers a new listener', ->
         expect(@robot.listeners).to.have.length(0)
@@ -332,6 +338,19 @@ describe 'Robot', ->
           expect(@robot.logger.warning).to.have.been.called
 
   describe 'Listener Registration', ->
+    describe '#listen', ->
+      it 'forwards the matcher, options, and callback to Listener', ->
+        callback = sinon.spy()
+        matcher = sinon.spy()
+        options = {}
+
+        @robot.listen(matcher, options, callback)
+        testListener = @robot.listeners[0]
+
+        expect(testListener.matcher).to.equal(matcher)
+        expect(testListener.callback).to.equal(callback)
+        expect(testListener.options).to.equal(options)
+
     describe '#hear', ->
       it 'matches TextMessages', ->
         callback = sinon.spy()

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -136,46 +136,46 @@ describe 'Robot', ->
         expect(match2).to.equal('message123')
 
     describe '#listen', ->
-      it 'registers a new listener', ->
+      it 'registers a new listener directly', ->
         expect(@robot.listeners).to.have.length(0)
-        @robot.hear /.*/, ->
+        @robot.listen (->), ->
         expect(@robot.listeners).to.have.length(1)
 
     describe '#hear', ->
-      it 'registers a new listener', ->
+      it 'registers a new listener directly', ->
         expect(@robot.listeners).to.have.length(0)
         @robot.hear /.*/, ->
         expect(@robot.listeners).to.have.length(1)
 
     describe '#respond', ->
-      it 'registers a new listener', ->
-        expect(@robot.listeners).to.have.length(0)
+      it 'registers a new listener using hear', ->
+        sinon.spy @robot, 'hear'
         @robot.respond /.*/, ->
-        expect(@robot.listeners).to.have.length(1)
+        expect(@robot.hear).to.have.been.called
 
     describe '#enter', ->
-      it 'registers a new listener', ->
-        expect(@robot.listeners).to.have.length(0)
+      it 'registers a new listener using listen', ->
+        sinon.spy @robot, 'listen'
         @robot.enter ->
-        expect(@robot.listeners).to.have.length(1)
+        expect(@robot.listen).to.have.been.called
 
     describe '#leave', ->
-      it 'registers a new listener', ->
-        expect(@robot.listeners).to.have.length(0)
+      it 'registers a new listener using listen', ->
+        sinon.spy @robot, 'listen'
         @robot.leave ->
-        expect(@robot.listeners).to.have.length(1)
+        expect(@robot.listen).to.have.been.called
 
     describe '#topic', ->
-      it 'registers a new listener', ->
-        expect(@robot.listeners).to.have.length(0)
+      it 'registers a new listener using listen', ->
+        sinon.spy @robot, 'listen'
         @robot.topic ->
-        expect(@robot.listeners).to.have.length(1)
+        expect(@robot.listen).to.have.been.called
 
     describe '#catchAll', ->
-      it 'registers a new listener', ->
-        expect(@robot.listeners).to.have.length(0)
+      it 'registers a new listener using listen', ->
+        sinon.spy @robot, 'listen'
         @robot.catchAll ->
-        expect(@robot.listeners).to.have.length(1)
+        expect(@robot.listen).to.have.been.called
 
     describe '#receive', ->
       it 'calls all registered listeners', ->


### PR DESCRIPTION
I got annoyed with #871 and decided to rip out the refactor by itself.

Allow the creation of Listeners with custom match logic
Refactor to consolidate array manipulation logic

Known issue: Robot.hear still creates TextListeners. Eventually, I'd like to get that moved over to just a standard Listener with special match logic, but need to decide what to do with the potential interface changes.

**This introduces `Robot.listen` as a new public method**