### PR TITLE
Add link to the Telegram Bot API adapter.

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -40,6 +40,7 @@ to have yours added to the list:
 * [Slack](https://github.com/tinyspeck/hubot-slack)
 * [Skype](https://github.com/netpro2k/hubot-skype)
 * [Talker](https://github.com/unixcharles/hubot-talker)
+* [Telegram](https://github.com/lukefx/hubot-telegram)
 * [Twilio](https://github.com/jkarmel/hubot-twilio)
 * [Twitter](https://github.com/MathildeLemee/hubot-twitter)
 * [Typetalk](https://github.com/nulab/hubot-typetalk)


### PR DESCRIPTION
I included a link to a library I developed that allows interacting with [Telegram](https://telegram.org/) using the [Telegram Bot API](https://core.telegram.org/bots/api).

The library used to connect to Telegram currently supports all the available calls.