### PR TITLE
Pass alias in Robot constructor. Fixes issue #1002.

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -84,13 +84,11 @@ if Options.create
 else
   adapterPath = Path.join __dirname, "..", "src", "adapters"
 
-  robot = Hubot.loadBot adapterPath, Options.adapter, Options.enableHttpd, Options.name
+  robot = Hubot.loadBot adapterPath, Options.adapter, Options.enableHttpd, Options.name, Options.alias
 
   if Options.version
     console.log robot.version
     process.exit 0
-
-  robot.alias = Options.alias
 
   loadScripts = ->
     scriptsPath = Path.resolve ".", "scripts"

--- a/index.coffee
+++ b/index.coffee
@@ -22,5 +22,5 @@ module.exports = {
   CatchAllMessage
 }
 
-module.exports.loadBot = (adapterPath, adapterName, enableHttpd, botName) ->
-  new Robot adapterPath, adapterName, enableHttpd, botName
+module.exports.loadBot = (adapterPath, adapterName, enableHttpd, botName, botAlias) ->
+  new Robot adapterPath, adapterName, enableHttpd, botName, botAlias

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -38,11 +38,11 @@ class Robot
   # name        - A String of the robot name, defaults to Hubot.
   #
   # Returns nothing.
-  constructor: (adapterPath, adapter, httpd, name = 'Hubot') ->
+  constructor: (adapterPath, adapter, httpd, name = 'Hubot', alias = false) ->
     @name      = name
     @events    = new EventEmitter
     @brain     = new Brain @
-    @alias     = false
+    @alias     = alias
     @adapter   = null
     @Response  = Response
     @commands  = []


### PR DESCRIPTION
This PR enables passing alias to robot's constructor. It fixes #1002. It also does not disturb in any way any existing 3rd party code as it doesn't change the behavior of robot's constructor without the extra param being passed.

But why?
Because both Robot name and alias should be provided during creation of the robot. In the current design they can not be changed later and are hard-coded into every listener's regex. Therefore modifying alias or name after the robot is created is wrong and could cause problems.