### PR TITLE
clarify that a room token might be the expected parameter

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -380,7 +380,7 @@ The most common use of this is for providing HTTP end points for services with w
 
 ```coffeescript
 module.exports = (robot) ->
-  robot.router.post '/hubot/chatsecrets/:room', (req, res) ->
+  robot.router.post '/hubot/chatsecrets/:room_name_or_token', (req, res) ->
     room   = req.params.room
     data   = if req.body.payload? then JSON.parse req.body.payload else req.body
     secret = data.secret

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -380,7 +380,8 @@ The most common use of this is for providing HTTP end points for services with w
 
 ```coffeescript
 module.exports = (robot) ->
-  robot.router.post '/hubot/chatsecrets/:room_name_or_token', (req, res) ->
+  # the expected value of :room is going to vary by adapter, it might be a numeric id, name, token, or some other value
+  robot.router.post '/hubot/chatsecrets/:room', (req, res) ->
     room   = req.params.room
     data   = if req.body.payload? then JSON.parse req.body.payload else req.body
     secret = data.secret


### PR DESCRIPTION
Hi,

Thanks for such an amazing project.  :)

I was testing out a hubot installation that uses the let's chat adapter.  So I'm not sure if this change only applies to the let's chat adapter or if it is applicable to all adapters.  That also means, I'm not sure if this is the correct place to update the docs.

Anyways, I couldn't get hubot to "hear" my curl request using just the chat room name.  Instead I needed to pass the chat room token to it.

Sorry, if this document change is way off.

Thanks again!