### PR TITLE
Add coffee-errors to test scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "hubot-mock-adapter": "^1.0.0",
+    "coffee-errors": "0.8.6",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
     "sinon-chai": "^2.6.0"

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source script/bootstrap
-mocha --compilers coffee:coffee-script "$@"
+mocha --require coffee-errors --compilers coffee:coffee-script "$@"


### PR DESCRIPTION
Line numbers from `script/test` are correct now.