### PR TITLE
Response middleware

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -800,6 +800,7 @@ by [Slack](https://slack.com), <https://example.com|example>.
 ```coffeescript
 module.exports = (robot) ->
   robot.responseMiddleware (context, next, done) ->
+    return unless context.plaintext?
     context.strings = (string.replace(/\[([^\[\]]*?)\]\((https?:\/\/.*?)\)/, "<$2|$1>") for string in context.strings)
     next()
 ```
@@ -815,3 +816,5 @@ of `next` and `done`. Receive middleware context includes these fields:
     - An array of strings being sent to the chat room adapter. You can edit these, or use `context.strings = ["new strings"]` to replace them.
   - `method`
     - A string representing which type of response message the listener sent, such as `send`, `reply`, `emote` or `topic`.
+  - `plaintext`
+    - `true` or `undefined`. This will be set to `true` if the message is of a normal plaintext type, such as `send` or `reply`. This property should be treated as read-only.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -812,3 +812,5 @@ of `next` and `done`. Receive middleware context includes these fields:
     - This response object can be used to send new messages from the middleware. Middleware will be called on these new responses. Be careful not to create infinite loops.
   - `strings`
     - An array of strings being sent to the chat room adapter. You can edit these, or use `context.strings = ["new strings"]` to replace them.
+  - `method`
+    - A string representing which type of response message the listener sent, such as `send`, `reply`, `emote` or `topic`.

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -19,7 +19,18 @@ class Response
   #
   # Returns nothing.
   send: (strings...) ->
-    @robot.adapter.send @envelope, strings...
+    adapter = @robot.adapter
+    for string in strings
+      return string() if typeof(string) == 'function'
+      context = {response: @, string: string}
+      responseMiddlewareDone = ->
+      runAdapterSend = (_, done) =>
+        @robot.adapter.send @envelope, context.string, done
+      @robot.middleware.response.execute context,
+                                         runAdapterSend,
+                                         responseMiddlewareDone
+
+
 
   # Public: Posts an emote back to the chat source
   #

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -73,7 +73,7 @@ class Response
     copy = strings.slice(0)
     if typeof(copy[copy.length - 1]) == 'function'
       callback = copy.pop()
-    context = {response: @, strings: copy}
+    context = {response: @, strings: copy, method: methodName}
     responseMiddlewareDone = ->
     runAdapterSend = (_, done) =>
       result = context.strings

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -78,7 +78,7 @@ class Response
     runAdapterSend = (_, done) =>
       result = context.strings
       result.push(callback) if callback?
-      @robot.adapter[methodName](@envelope, result)
+      @robot.adapter[methodName](@envelope, result...)
       done()
     @robot.middleware.response.execute context,
                                        runAdapterSend,

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -19,18 +19,7 @@ class Response
   #
   # Returns nothing.
   send: (strings...) ->
-    adapter = @robot.adapter
-    for string in strings
-      return string() if typeof(string) == 'function'
-      context = {response: @, string: string}
-      responseMiddlewareDone = ->
-      runAdapterSend = (_, done) =>
-        @robot.adapter.send @envelope, context.string, done
-      @robot.middleware.response.execute context,
-                                         runAdapterSend,
-                                         responseMiddlewareDone
-
-
+    @runWithMiddleware("send", strings...)
 
   # Public: Posts an emote back to the chat source
   #
@@ -39,7 +28,7 @@ class Response
   #
   # Returns nothing.
   emote: (strings...) ->
-    @robot.adapter.emote @envelope, strings...
+    @runWithMiddleware("emote", strings...)
 
   # Public: Posts a message mentioning the current user.
   #
@@ -48,7 +37,7 @@ class Response
   #
   # Returns nothing.
   reply: (strings...) ->
-    @robot.adapter.reply @envelope, strings...
+    @runWithMiddleware("reply", strings...)
 
   # Public: Posts a topic changing message
   #
@@ -57,7 +46,7 @@ class Response
   #
   # Returns nothing.
   topic: (strings...) ->
-    @robot.adapter.topic @envelope, strings...
+    @runWithMiddleware("topic", strings...)
 
   # Public: Play a sound in the chat source
   #
@@ -66,7 +55,7 @@ class Response
   #
   # Returns nothing
   play: (strings...) ->
-    @robot.adapter.play @envelope, strings...
+    @runWithMiddleware("play", strings...)
 
   # Public: Posts a message in an unlogged room
   #
@@ -75,7 +64,20 @@ class Response
   #
   # Returns nothing
   locked: (strings...) ->
-    @robot.adapter.locked @envelope, strings...
+    @runWithMiddleware("locked", strings...)
+
+  # Private: Call with a method for the given strings using response
+  # middleware.
+  runWithMiddleware: (methodName, strings...) ->
+    for string in strings
+      return string() if typeof(string) == 'function'
+      context = {response: @, string: string}
+      responseMiddlewareDone = ->
+      runAdapterSend = (_, done) =>
+        @robot.adapter[methodName](@envelope, context.string, done)
+      @robot.middleware.response.execute context,
+                                         runAdapterSend,
+                                         responseMiddlewareDone
 
   # Public: Picks a random item from the given items.
   #

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -19,7 +19,7 @@ class Response
   #
   # Returns nothing.
   send: (strings...) ->
-    @runWithMiddleware("send", strings...)
+    @runWithMiddleware("send", { plaintext: true }, strings...)
 
   # Public: Posts an emote back to the chat source
   #
@@ -28,7 +28,7 @@ class Response
   #
   # Returns nothing.
   emote: (strings...) ->
-    @runWithMiddleware("emote", strings...)
+    @runWithMiddleware("emote", { plaintext: true }, strings...)
 
   # Public: Posts a message mentioning the current user.
   #
@@ -37,7 +37,7 @@ class Response
   #
   # Returns nothing.
   reply: (strings...) ->
-    @runWithMiddleware("reply", strings...)
+    @runWithMiddleware("reply", { plaintext: true }, strings...)
 
   # Public: Posts a topic changing message
   #
@@ -46,7 +46,7 @@ class Response
   #
   # Returns nothing.
   topic: (strings...) ->
-    @runWithMiddleware("topic", strings...)
+    @runWithMiddleware("topic", { plaintext: true }, strings...)
 
   # Public: Play a sound in the chat source
   #
@@ -64,16 +64,17 @@ class Response
   #
   # Returns nothing
   locked: (strings...) ->
-    @runWithMiddleware("locked", strings...)
+    @runWithMiddleware("locked", { plaintext: true }, strings...)
 
   # Private: Call with a method for the given strings using response
   # middleware.
-  runWithMiddleware: (methodName, strings...) ->
+  runWithMiddleware: (methodName, opts, strings...) ->
     callback = undefined
     copy = strings.slice(0)
     if typeof(copy[copy.length - 1]) == 'function'
       callback = copy.pop()
     context = {response: @, strings: copy, method: methodName}
+    context.plaintext = true if opts.plaintext?
     responseMiddlewareDone = ->
     runAdapterSend = (_, done) =>
       result = context.strings

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -51,6 +51,7 @@ class Robot
     @listeners  = []
     @middleware =
       listener: new Middleware(@)
+      response: new Middleware(@)
     @logger     = new Log process.env.HUBOT_LOG_LEVEL or 'info'
     @pingIntervalId = null
     @globalHttpOptions = {}
@@ -235,6 +236,21 @@ class Robot
   # Returns nothing.
   listenerMiddleware: (middleware) ->
     @middleware.listener.register middleware
+    return undefined
+
+  # Public: Registers new middleware for execution as a response to any
+  # message is being sent.
+  #
+  # middleware - A function that examines an outgoing message and can modify
+  #              it or prevent its sending. The function is called with
+  #              (context, next, done). If execution should continue,
+  #              the middleware should call next(done). If execution should stop,
+  #              the middleware should call done(). To modify the outgoing message,
+  #              set context.string to a new message.
+  #
+  # Returns nothing.
+  responseMiddleware: (middleware) ->
+    @middleware.response.register middleware
     return undefined
 
   # Public: Passes the given message to any interested Listeners.

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -813,6 +813,7 @@ describe 'Robot', ->
         @robot.responseMiddleware (context, next, done) ->
           # We don't send the callback function to middleware, so it's not here.
           expect(context.strings).to.deep.equal ["foobar, sir, foobar."]
+          expect(context.method).to.equal "send"
           asserted = true
           next()
 

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -647,3 +647,20 @@ describe 'Robot', ->
             'doneA'
           ])
           testDone()
+
+    describe 'Response Middleware', ->
+      it 'allows listener callback execution', (testDone) ->
+        @robot.adapter.send = sendSpy = sinon.spy()
+        listenerCallback = sinon.spy()
+        @robot.hear /^message123$/, (response) ->
+          response.send "foobar, sir, foobar."
+
+        @robot.responseMiddleware (context, next, done) ->
+          context.string = context.string.replace(/foobar/g, "barfoo")
+          console.log "string in middleware: #{context.string}"
+          next done
+
+        testMessage = new TextMessage @user, 'message123'
+        @robot.receive testMessage, () ->
+          expect(sendSpy.getCall(0).args[1]).to.equal('barfoo, sir, barfoo.')
+          testDone()

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -785,7 +785,7 @@ describe 'Robot', ->
 
         testMessage = new TextMessage @user, 'message123'
         @robot.receive testMessage, () ->
-          expect(sendSpy.getCall(0).args[1][0]).to.equal('replaced bar-foo, sir, replaced bar-foo.')
+          expect(sendSpy.getCall(0).args[1]).to.equal('replaced bar-foo, sir, replaced bar-foo.')
           testDone()
 
       it 'allows replacing outgoing strings', (testDone) ->
@@ -800,7 +800,7 @@ describe 'Robot', ->
 
         testMessage = new TextMessage @user, 'message123'
         @robot.receive testMessage, () ->
-          expect(sendSpy.getCall(0).args[1]).to.deep.equal(["whatever I want."])
+          expect(sendSpy.getCall(0).args[1]).to.deep.equal("whatever I want.")
           testDone()
 
       it 'does not send trailing functions to middleware', (testDone) ->
@@ -820,6 +820,6 @@ describe 'Robot', ->
         testMessage = new TextMessage @user, 'message123'
         @robot.receive testMessage, ->
           expect(asserted).to.equal(true)
-          expect(sendSpy.getCall(0).args[1][0]).to.equal('foobar, sir, foobar.')
-          expect(sendSpy.getCall(0).args[1][1]).to.equal(postSendCallback)
+          expect(sendSpy.getCall(0).args[1]).to.equal('foobar, sir, foobar.')
+          expect(sendSpy.getCall(0).args[2]).to.equal(postSendCallback)
           testDone()


### PR DESCRIPTION
Hot on the heels of #1019, response middleware gives you the chance to edit outgoing messages.

It looks like this:

```coffeescript
# Replace markdown links with slack's <url|text> format.
module.exports = (robot) ->
  robot.responseMiddleware (context, next, done) ->
    regex = /\[([^\[\]]*?)\]\((https?:\/\/.*?)\)/g

    context.string = context.string.replace(regex, "<$2|$1>")
    next(done)
```