### PR TITLE
Make "done" argument optional for middleware

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -121,14 +121,14 @@ module.exports = (robot) ->
     if context.listener.options.id in POWER_COMMANDS
       if context.response.message.user.id in POWER_USERS
         # User is allowed access to this command
-        next(done)
+        next()
       else
         # Restricted command, but user isn't in whitelist
         context.response.reply "I'm sorry, @#{context.response.message.user.name}, but you don't have access to do that."
         done()
     else
       # This is not a restricted command; allow everyone
-      next(done)
+      next()
 ```
 
 Remember that middleware executes for ALL listeners that match a given message (including `robot.hear /.+/`), so make sure you include them when categorizing your listeners.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -655,7 +655,7 @@ module.exports = (robot) ->
     # Log commands
     robot.logger.info "#{context.response.message.user.name} asked me to #{context.response.message.text}"
     # Continue executing middleware
-    next(done)
+    next()
 ```
 
 In this example, a log message will be written for each chat message that matches a Listener.
@@ -678,7 +678,7 @@ module.exports = (robot) ->
         # Command is being executed too quickly!
         done()
       else
-        next () ->
+        next ->
           lastExecutedTime[context.listener.options.id] = Date.now()
           done()
     catch err
@@ -712,7 +712,7 @@ Although internal data structures are exposed, not all properties on the objects
 
 - `next`
   - a Function with no additional properties that should be called to continue on to the next piece of middleware/execute the Listener callback
-  - `next` should be called with a single argument: either the provided `done` function or a new function that eventually calls `done`
+  - `next` should be called with a single optional argument: either the provided `done` function or a new function that eventually calls `done`
 
 - `done`
  - a Function with no additional properties that should be called to interrupt middleware execution and begin executing the chain of completion functions.

--- a/src/middleware.coffee
+++ b/src/middleware.coffee
@@ -26,7 +26,7 @@ class Middleware
     # logic).
     executeSingleMiddleware = (doneFunc, middlewareFunc, cb) =>
       # Match the async.reduce interface
-      nextFunc = (newDoneFunc) -> cb(null, newDoneFunc)
+      nextFunc = (newDoneFunc) -> cb(null, newDoneFunc or doneFunc)
       # Catch errors in synchronous middleware
       try
         middlewareFunc.call(undefined, context, nextFunc, doneFunc)
@@ -50,7 +50,8 @@ class Middleware
   #              continue the pipeline or interrupt it. The function is called
   #              with (robot, context, next, done). If execution should
   #              continue (next middleware, final callback), the middleware
-  #              should call the 'next' function with 'done' as an argument.
+  #              should call the 'next' function with 'done' as an optional
+  #              argument.
   #              If not, the middleware should call the 'done' function with
   #              no arguments. Middleware may wrap the 'done' function in
   #              order to execute logic after the final callback has been

--- a/test/middleware_test.coffee
+++ b/test/middleware_test.coffee
@@ -168,6 +168,35 @@ describe 'Middleware', ->
           allDone
         )
 
+      it 'defaults to the latest done callback if none is provided', (testDone) ->
+        # we want to ensure that the 'done' callbacks are nested correctly
+        # (executed in reverse order of definition)
+        execution = []
+
+        testMiddlewareA = (context, next, done) ->
+          execution.push 'middlewareA'
+          next () ->
+            execution.push 'doneA'
+            done()
+
+        testMiddlewareB = (context, next, done) ->
+          execution.push 'middlewareB'
+          next()
+
+        @middleware.register testMiddlewareA
+        @middleware.register testMiddlewareB
+
+        allDone = () ->
+          expect(execution).to.deep.equal(['middlewareA', 'middlewareB', 'doneA'])
+          testDone()
+
+        @middleware.execute(
+          {}
+          # Short circuit at the bottom of the middleware stack
+          (_, done) -> done()
+          allDone
+        )
+
       describe 'error handling', ->
         it 'does not execute subsequent middleware after the error is thrown', (testDone) ->
           middlewareExecution = []


### PR DESCRIPTION
Default to using the most recent 'done' callback if not explicitly specified.

Allows `next()` instead of `next done`.

Minor version bump