### PR TITLE
Remove unnecessary instance variable in Robot

### DIFF
--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -1,6 +1,7 @@
 {inspect} = require 'util'
 async     = require 'async'
 
+Response = require './response'
 {TextMessage} = require './message'
 Middleware = require './middleware'
 
@@ -75,7 +76,7 @@ class Listener
         if cb?
           process.nextTick -> cb true
 
-      response = new @robot.Response(@robot, message, match)
+      response = new Response(@robot, message, match)
       middleware.execute(
         {listener: @, response: response}
         executeListener

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -46,7 +46,6 @@ class Robot
     @brain      = new Brain @
     @alias      = false
     @adapter    = null
-    @Response   = Response
     @commands   = []
     @listeners  = []
     @middleware =
@@ -262,7 +261,7 @@ class Robot
               # Stop processing when message.done == true
               cb(message.done)
         catch err
-          @emit('error', err, new @Response(@, message, []))
+          @emit('error', err, new Response(@, message, []))
           # Continue to next listener when there is an error
           cb(false)
       ,


### PR DESCRIPTION
Introduced in 1e4ae576aa6fbcade3cd7204a6102e6ddbfca4c7 for no apparent reason. Given the amount of refactoring that has occurred to move each class into its own file, this should be completely unnecessary now.