### PR TITLE
Prepare for v2.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v2.15.0
+=======
+
+* Document another middleware pattern https://github.com/github/hubot/pull/1017
+* Make Robot.respondPattern a public method https://github.com/github/hubot/pull/1011
+* Make "done" argument optional for middleware https://github.com/github/hubot/pull/1028
+
 v2.14.0
 =======
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "hubot",
   "keywords": [
     "github",


### PR DESCRIPTION
* Document another middleware pattern https://github.com/github/hubot/pull/1017 @kristenmills 
* Make Robot.respondPattern a public method https://github.com/github/hubot/pull/1011 @sdimkov 
* Make "done" argument optional for middleware https://github.com/github/hubot/pull/1028 @michaelansel

All changes: https://github.com/github/hubot/compare/v2.14.0...master

@github/open-source-hubot-maintainers 