### PR TITLE
Update docs on keepalive support

### DIFF
--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -39,19 +39,6 @@ scripts, you'd need to set the following environment variables:
     % heroku config:set HUBOT_CAMPFIRE_TOKEN=yourcampfiretoken
     % heroku config:set HUBOT_CAMPFIRE_ROOMS=comma,separated,list,of,rooms,to,join
 
-In addition, there is one special environment variable for Heroku. The default hubot
-[Procfile](https://devcenter.heroku.com/articles/procfile) marks the process as
-a 'web' process type, in order to support serving http requests (more on that
-in the [scripting docs](/docs/scripting.md)). The downside of this is that dynos
-will [idle after an hour of inactivity](https://devcenter.heroku.com/articles/dynos#dyno-idling).
-That means your hubot would leave after an hour of idle web traffic, and only rejoin when it does get traffic. This is extremely
-inconvenient since most interaction is done through chat, and hubot has to be online and in the room to respond to messages. To get around this,
-there's a special environment variable to make hubot regularly ping itself over http. If
-the app is deployed to http://rosemary-britches-123.herokuapp.com/, you'd
-configure:
-
-    % heroku config:set HEROKU_URL=http://rosemary-britches-123.herokuapp.com
-
 At this point, you are ready to deploy and start chatting. With Heroku, that's a
 git push away:
 
@@ -72,3 +59,5 @@ before:
 Some scripts needs Redis to work, Heroku offers an addon called [Redis Cloud](https://addons.heroku.com/rediscloud), which has a free plan. To use it:
 
     % heroku addons:add rediscloud
+
+Free dynos on Heroku will [sleep after 30 minutes of inactivity](https://devcenter.heroku.com/articles/dyno-sleeping). That means your hubot would leave the chat room and only rejoin when it does get traffic. This is extremely inconvenient since most interaction is done through chat, and hubot has to be online and in the room to respond to messages. To get around this, you can use the [hubot-heroku-keepalive](https://github.com/hubot-scripts/hubot-heroku-keepalive) script, which will keep your free dyno alive for up to 18 hours/day. If you never want Hubot to sleep, you will need to [upgrade to Heroku's hobby plan](https://www.heroku.com/pricing).


### PR DESCRIPTION
This updates the heroku docs to be consistent with the changes in https://github.com/hubot-scripts/hubot-heroku-keepalive/pull/13. I moved this to the bottom since it's not essential for getting hubot running the first time.

/cc @github/open-source-hubot-maintainers 
