### PR TITLE
Update Slack adapter to new home

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -37,7 +37,7 @@ to have yours added to the list:
 * [QQ](https://github.com/xhan/qqbot)
 * [Partychat](https://github.com/iangreenleaf/hubot-partychat-hooks)
 * [Rocket.Chat](https://github.com/RocketChat/hubot-rocketchat)
-* [Slack](https://github.com/tinyspeck/hubot-slack)
+* [Slack](https://github.com/slackhq/hubot-slack)
 * [Skype](https://github.com/netpro2k/hubot-skype)
 * [SkypeWeb](https://github.com/sdimkov/hubot-skype-web)
 * [Talker](https://github.com/unixcharles/hubot-talker)


### PR DESCRIPTION
The Slack adapter has been moved to https://github.com/slackhq/hubot-slack
 and is redirecting, but this link is still going to the old repo location.