### PR TITLE
File-scoped metadata

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -638,6 +638,20 @@ module.exports = (robot) ->
     # code to stop annoying someone
 ```
 
+You can scope all listeners in a file with the `listenerOptions` function:
+
+```coffeescript
+module.exports = (robot) ->
+  robot.listenerOptions annoying: true
+  robot.respond /annoy me/, (msg) ->
+    # code to annoy someone. This listener will have annoying: true as its
+    # metadata.
+
+  robot.respond /unannoy me/, annoying: false, (msg) ->
+    # Code to stop annoying someone. This lisenter will have annoying: false
+    # as its metadata
+```
+
 These scoped identifiers allow you to externally specify new behaviors like:
 - authorization policy: "allow everyone in the `annoyers` group to execute `annoyance.*` commands"
 - rate limiting: "only allow executing `annoyance.start` once every 30 minutes"

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -27,6 +27,14 @@ class Listener
     if not @options.id?
       @options.id = null
 
+    if @robot.defaultOptions?
+      newOptions = {}
+      for key, val of @robot.defaultOptions
+        newOptions[key] = val
+      for key, val of @options
+        newOptions[key] = val
+      @options = newOptions
+
     if not @callback? or typeof @callback != 'function'
       throw new Error "Missing a callback for Listener"
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -322,6 +322,12 @@ class Robot
     )
     return undefined
 
+  # Public: Adds default metadata for all remaining listeners defined in a
+  # given file.
+  #
+  # Returns nothing.
+  listenerOptions: (metadata) ->
+    @defaultOptions = metadata
 
   # Public: Loads a file in path.
   #
@@ -338,6 +344,7 @@ class Robot
 
         if typeof script is 'function'
           script @
+          @listenerOptions(undefined)
           @parseHelp Path.join(path, file)
         else
           @logger.warning "Expected #{full} to assign a function to module.exports, got #{typeof script}"

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -341,6 +341,31 @@ describe 'Robot', ->
           @robot.loadFile('./scripts', 'test-script.coffee')
           expect(@robot.parseHelp).to.have.been.calledWith('scripts/test-script.coffee')
 
+      describe 'scoped metadata', ->
+        it 'applies file-scoped metadata to listeners defined with defaultOptions', ->
+          module = require 'module'
+          @script = sinon.spy (robot) ->
+            robot.listenerOptions fooEnabled: true
+            robot.respond /foo/, barEnabled: true, (response) ->
+              response.send "foo"
+            robot.respond /bar/, fooEnabled: false, (response) ->
+              response.send "bar"
+
+          @scriptWithoutDefaults = sinon.spy (robot) ->
+            robot.respond /baz/, (response) ->
+              response.send "foo"
+
+          stub = @sandbox.stub(module, '_load').onCall(0).returns(@script)
+          stub.onCall(0).returns(@script)
+          stub.onCall(1).returns(@scriptWithoutDefaults)
+          @sandbox.stub @robot, 'parseHelp'
+
+          @robot.loadFile('./scripts', 'test-script.coffee')
+          @robot.loadFile('./scripts', 'test-script-2.coffee')
+          expect(@robot.listeners[0].options).to.deep.equal { fooEnabled: true, barEnabled: true, id: null }
+          expect(@robot.listeners[1].options).to.deep.equal { fooEnabled: false, id: null }
+          expect(@robot.listeners[2].options).to.deep.equal { id: null }
+
       describe 'non-Function script', ->
         beforeEach ->
           module = require 'module'
@@ -366,7 +391,7 @@ describe 'Robot', ->
 
         expect(testListener.matcher).to.equal(matcher)
         expect(testListener.callback).to.equal(callback)
-        expect(testListener.options).to.equal(options)
+        expect(testListener.options).to.deep.equal(options)
 
     describe '#hear', ->
       it 'matches TextMessages', ->


### PR DESCRIPTION
This PR adds `robot.listenerOptions metadataItem: true`. All listeners defined in a file after this call will extend this metadata rather than start from scratch. You can now do something like this:

```coffeescript
module.exports = (robot) ->
  robot.listenerOptions annoying: true
  robot.respond /annoy me/, (msg) ->
    # code to annoy someone. This listener will have annoying: true as its
    # metadata.

  robot.respond /unannoy me/, annoying: false, (msg) ->
    # Code to stop annoying someone. This lisenter will have annoying: false
    # as its metadata
```

@technicalpickles and I are running through a large existing codebase and found a few users for this. Some files have a lot of functions, and adding something like `deployment: true` to tag all commands related to deployment is pretty tedious and not very helpful. We're also enabling commands 1-by-1 for a new chat service after an audit, and adding `fooEnabled:` to every single command we have is getting ridiculous, and will result in a lot of diff churn when it's time to pull them out.

cc @michaelansel 