### PR TITLE
Only coerce ids that are all digits into integers

### DIFF
--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -42,7 +42,10 @@ class Shell extends Adapter
     @cli = cline()
 
     @cli.command '*', (input) =>
-      userId = parseInt(process.env.HUBOT_SHELL_USER_ID or '1')
+      userId = process.env.HUBOT_SHELL_USER_ID or '1'
+      if userId.match (/\A\d+\z/)
+        userId = parseInt(userId)
+
       userName = process.env.HUBOT_SHELL_USER_NAME or 'Shell'
       user = @robot.brain.userForId userId, name: userName, room: 'Shell'
       @receive new TextMessage user, input, 'messageId'


### PR DESCRIPTION
This lets you set a HUBOT_SHELL_USER_ID=U0123456, as if to pretend to
have a Slack user id.

Without this change, `parseInt` ends up returning undefined for strings like `U0123456`.