### PR TITLE
Fix link to Deploying index

### DIFF
--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -3,7 +3,7 @@ permalink: /docs/deploying/heroku/index.html
 layout: docs
 ---
 
-If you've been following along with [Getting Started](../../index.md), it's time to deploy so you can use it beyond just your local machine.
+If you've been following along with [Getting Started](/docs/deploying/), it's time to deploy so you can use it beyond just your local machine.
 [Heroku](http://www.heroku.com/) is an easy and supported way to deploy hubot.
 
 Install the [Heroku Toolbelt](https://toolbelt.heroku.com/) to start, then follow their 'Getting Started' instructions, including logging in the first time:


### PR DESCRIPTION
It's currently pointing to https://hubot.github.com/docs/deploying/index/ (which is a 404)