### PR TITLE
Only loadScripts once

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -132,6 +132,6 @@ else
     console.log "OK"
     process.exit 0
 
-  robot.adapter.on 'connected', loadScripts
+  robot.adapter.once 'connected', loadScripts
 
   robot.run()


### PR DESCRIPTION
This should fix https://github.com/slackhq/hubot-slack/issues/210 over in hubot-slack. I'm not sure if there's any other implications of this, like if other adapters have workarounds for this or not.