### PR TITLE
Only load scripts the first time the adapter connects

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -132,6 +132,6 @@ else
     console.log "OK"
     process.exit 0
 
-  robot.adapter.on 'connected', loadScripts
+  robot.adapter.once 'connected', loadScripts
 
   robot.run()


### PR DESCRIPTION
This should fix issue #919 where hubot reloads scripts
each time the adapter emits `'connected'`

Because some adapters handle retries for lost connections, they
may emit such an event many times. However hubot should not load
scripts more than once.

No tests added, `bin/hubot` is hardly testable and the modification
does not break any existing test