### PR TITLE
Debug log listener options when exec callback

### DIFF
--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -55,7 +55,7 @@ class Listener
     if match = @matcher message
       if @regex
         @robot.logger.debug \
-          "Message '#{message}' matched regex /#{inspect @regex}/"
+          "Message '#{message}' matched regex /#{inspect @regex}/; listener.options = #{inspect @options}"
 
       # special middleware-like function that always executes the Listener's
       # callback and calls done (never calls 'next')


### PR DESCRIPTION
This makes debugging easier because you can more easily identify which
listener is being executed. This changes the debug output from -- e.g.:

    [Tue Oct 27 2015 07:35:47 GMT-0700 (PDT)] DEBUG Message 'DEVOPS-916' matched regex //(.*)$/i/
    [Tue Oct 27 2015 07:23:59 GMT-0700 (PDT)] DEBUG Executing listener callback for Message 'DEVOPS-916'

to the more helpful:

    [Tue Oct 27 2015 07:35:47 GMT-0700 (PDT)] DEBUG Message 'DEVOPS-916' matched regex //(.*)$/i/; @options = { id: 'hubot-mute.catch_all' }
    [Tue Oct 27 2015 07:28:10 GMT-0700 (PDT)] DEBUG Executing listener callback for Message 'DEVOPS-916'; @options = { id: 'hubot-mute.catch_all' }