### PR TITLE
Optionally use setImmediate instead of nextTick in middleware

### DIFF
--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -73,7 +73,7 @@ class Listener
         # Yes, we tried to execute the listener callback (middleware may
         # have intercepted before actually executing though)
         if cb?
-          process.nextTick -> cb true
+          Middleware.ticker -> cb true
 
       response = new @robot.Response(@robot, message, match)
       middleware.execute(

--- a/src/middleware.coffee
+++ b/src/middleware.coffee
@@ -1,6 +1,9 @@
 async = require 'async'
 
 class Middleware
+  # We use this recursively, and using nextTick recursively is deprecated in node 0.10.
+  @ticker: if typeof setImmediate is "function" then setImmediate else process.nextTick
+
   constructor: (@robot) ->
     @stack = []
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -303,7 +303,7 @@ class Robot
             anyListenersExecuted = anyListenersExecuted || listenerExecuted
             # Defer to the event loop at least after every listener so the
             # stack doesn't get too big
-            process.nextTick () ->
+            Middleware.ticker () ->
               # Stop processing when message.done == true
               cb(context.response.message.done)
         catch err


### PR DESCRIPTION
When upgrading from node 0.8 to 0.10, we were failing with errors like this:

```
... snip ...
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.

node.js:0
// Copyright Joyent, Inc. and other Node contributors.
^
RangeError: Maximum call stack size exceeded
```

This uses `setImmediate` instead of `nextTick` if available, allowing our hubot to boot.

cc @technicalpickles 