### PR TITLE
[+] Included Mattermost Hubot adapter

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -49,6 +49,7 @@ to have yours added to the list:
 * [Visual Studio Online](https://github.com/scrumdod/hubot-VSOnline)
 * [XMPP](https://github.com/markstory/hubot-xmpp)
 * [Yammer](https://github.com/athieriot/hubot-yammer)
+* [Mattermost](https://github.com/renanvicente/hubot-mattermost)
 
 ## Writing Your Own Adapter
 


### PR DESCRIPTION
Include [Mattermost](mattermost.org) Hubot adapter in the list