### PR TITLE
Add Skyweb to a list of adapters

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -40,6 +40,7 @@ to have yours added to the list:
 * [Slack](https://github.com/slackhq/hubot-slack)
 * [Skype](https://github.com/netpro2k/hubot-skype)
 * [SkypeWeb](https://github.com/sdimkov/hubot-skype-web)
+* [Skyweb](https://github.com/EllisV/hubot-skyweb)
 * [Talker](https://github.com/unixcharles/hubot-talker)
 * [Telegram](https://github.com/lukefx/hubot-telegram)
 * [Twilio](https://github.com/jkarmel/hubot-twilio)


### PR DESCRIPTION
Hello,

I would like to add a [Skyweb Adapter](https://github.com/EllisV/hubot-skyweb) which uses Skyweb library (communicates with Skype via HTTP) to a list of adapters.