### PR TITLE
Rename Hubot at runtime

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -148,6 +148,47 @@ class Robot
 
     newRegex
 
+  # Public: Updates the robot name and its listeners accordingly.
+  #
+  # newName - A String of the new robot name.
+  #
+  # Returns nothing.
+  changeName: (newName) ->
+    # Escapes names:
+    alias = @alias.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+    oldNameRegex = @name.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+    newNameRegex = newName.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+
+    # Updates the name.
+    @name = newName
+
+    # Updates listeners:
+    listeners = []
+    for listener in @listeners
+      if listener instanceof TextListener
+        # Extracts regex and modifiers:
+        re = listener.regex.toString().split('/')
+        re.shift()
+        modifiers = re.pop()
+        oldRegex = re.join('/')
+
+        if @alias
+        # Listener's regex also contains an alias.
+          [a,b] = if oldNameRegex.length > alias.length then [oldNameRegex,alias] else [alias,oldNameRegex]
+          oldStartRegex = "^\\s*[@]?(?:#{a}[:,]?|#{b}[:,]?)\\s*(?:"
+          [c,d] = if newNameRegex.length > alias.length then [newNameRegex,alias] else [alias,newNameRegex]
+          newStartRegex = "^\\s*[@]?(?:#{c}[:,]?|#{d}[:,]?)\\s*(?:"
+          regex = oldRegex.replace(oldStartRegex, newStartRegex)
+        else
+          oldStartRegex = "^\\s*[@]?#{oldNameRegex}[:,]?\\s*(?:"
+          newStartRegex = "^\\s*[@]?#{newNameRegex}[:,]?\\s*(?:"
+          regex = oldRegex.replace(oldNameRegex, newNameRegex)
+        re = new RegExp(regex, modifiers)
+        listeners.push new TextListener(@, re, listener.options, listener.callback)
+      else
+        listeners.push listener
+    @listeners = listeners
+
   # Public: Adds a Listener that triggers when anyone enters the room.
   #
   # options  - An Object of additional parameters keyed on extension name

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -82,6 +82,20 @@ describe 'Robot', ->
         httpClient = @robot.http('http://localhost', agent: agentB)
         expect(httpClient.options.agent).to.equal(agentB)
 
+    describe '#changeName', ->
+      it 'updates the name', ->
+        expect(@robot.name).to.equal('TestHubot')
+        @robot.changeName 'Testbot'
+        expect(@robot.name).to.equal('Testbot')
+
+      it 'updates listeners with the new name', ->
+        @robot.respond /.*/, ->
+        regex = @robot.listeners[0].regex.toString()
+        expect(regex).to.equal('/^\\s*[@]?(?:TestHubot[:,]?|Hubot[:,]?)\\s*(?:.*)/')
+        @robot.changeName 'Testbot'
+        regex = @robot.listeners[0].regex.toString()
+        expect(regex).to.equal('/^\\s*[@]?(?:Testbot[:,]?|Hubot[:,]?)\\s*(?:.*)/')
+
     describe '#respondPattern', ->
       it 'matches messages starting with robot\'s name', ->
         testMessage = @robot.name + 'message123'
@@ -413,6 +427,19 @@ describe 'Robot', ->
         result = testListener.matcher(testMessage)
 
         expect(result).to.not.be.ok
+
+    describe '#changeName', ->
+      it 'still matches TextMessages addressed to the robot', ->
+        callback = sinon.spy()
+        testMessage = new TextMessage(@user, 'Testbot Message123')
+        testRegex = /message123$/i
+
+        @robot.respond(testRegex, callback)
+        @robot.changeName 'Testbot'
+
+        testListener = @robot.listeners[0]
+        result = testListener.matcher(testMessage)
+        expect(result).to.be.ok
 
     describe '#enter', ->
       it 'matches EnterMessages', ->


### PR DESCRIPTION
First implementation for #1093, this pull request adds a `changeName` to Robot to change its name at runtime. It updates the name and the `respond` listeners.
It replaces the beginning of listeners' regular expressions, which contains the name of the robot, instead of reconstructing them.

I'm not a big fan of this piece of code because it shares a lot with `respondPattern` and, it depends heavily on the `respond` regex.
An alternate solution is to reconstruct regular expressions using `respondPattern`. This strategy would, however, require to save the original regex (the message part that follows the robot's name/alias) in the TextListener object.