### PR TITLE
Use env var for setting limit and parameterLimit to express's urlenconder

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -395,6 +395,8 @@ module.exports = (robot) ->
 
 Hubot includes support for the [express](http://expressjs.com) web framework to serve up HTTP requests. It listens on the port specified by the `EXPRESS_PORT` or `PORT` environment variables (preferred in that order) and defaults to 8080. An instance of an express application is available at `robot.router`. It can be protected with username and password by specifying `EXPRESS_USER` and `EXPRESS_PASSWORD`. It can automatically serve static files by setting `EXPRESS_STATIC`.
 
+You can increase the [maximum request body size](https://github.com/expressjs/body-parser#limit-3) by specifying `EXPRESS_LIMIT`. It defaults to '100kb'.  You can also set the [maximum number of parameters](https://github.com/expressjs/body-parser#parameterlimit) that are allowed in the URL-encoded data by setting `EXPRESS_PARAMETER_LIMIT`. The default is `1000`.
+
 The most common use of this is for providing HTTP end points for services with webhooks to push to, and have those show up in chat.
 
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -429,7 +429,7 @@ class Robot
     app.use express.query()
 
     app.use express.json()
-    app.use express.urlencoded({limit: limit, parameterLimit: paramLimit})
+    app.use express.urlencoded(limit: limit, parameterLimit: paramLimit)
     # replacement for deprecated express.multipart/connect.multipart
     # limit to 100mb, as per the old behavior
     app.use multipart(maxFilesSize: 100 * 1024 * 1024)

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -414,7 +414,7 @@ class Robot
     port       = process.env.EXPRESS_PORT or process.env.PORT or 8080
     address    = process.env.EXPRESS_BIND_ADDRESS or process.env.BIND_ADDRESS or '0.0.0.0'
     limit      = process.env.EXPRESS_LIMIT or '100kb'
-    paramLimit = process.env.EXPRESS_PARAMETER_LIMIT or 1000
+    paramLimit = parseInt(process.env.EXPRESS_PARAMETER_LIMIT) or 1000
 
     express = require 'express'
     multipart = require 'connect-multiparty'

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -408,11 +408,13 @@ class Robot
   #
   # Returns nothing.
   setupExpress: ->
-    user    = process.env.EXPRESS_USER
-    pass    = process.env.EXPRESS_PASSWORD
-    stat    = process.env.EXPRESS_STATIC
-    port    = process.env.EXPRESS_PORT or process.env.PORT or 8080
-    address = process.env.EXPRESS_BIND_ADDRESS or process.env.BIND_ADDRESS or '0.0.0.0'
+    user       = process.env.EXPRESS_USER
+    pass       = process.env.EXPRESS_PASSWORD
+    stat       = process.env.EXPRESS_STATIC
+    port       = process.env.EXPRESS_PORT or process.env.PORT or 8080
+    address    = process.env.EXPRESS_BIND_ADDRESS or process.env.BIND_ADDRESS or '0.0.0.0'
+    limit      = process.env.EXPRESS_LIMIT or '100kb'
+    paramLimit = process.env.EXPRESS_PARAMETER_LIMIT or 1000
 
     express = require 'express'
     multipart = require 'connect-multiparty'
@@ -427,7 +429,7 @@ class Robot
     app.use express.query()
 
     app.use express.json()
-    app.use express.urlencoded()
+    app.use express.urlencoded({limit: limit, parameterLimit: paramLimit})
     # replacement for deprecated express.multipart/connect.multipart
     # limit to 100mb, as per the old behavior
     app.use multipart(maxFilesSize: 100 * 1024 * 1024)


### PR DESCRIPTION
For avoiding `413 Request Entity too large` in some responses.
fixes #1105 
