### PR TITLE
Determine adapterPath in robot.coffee, rather than bin/hubot

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -82,9 +82,7 @@ if Options.create
   process.exit 1
 
 else
-  adapterPath = Path.join __dirname, "..", "src", "adapters"
-
-  robot = Hubot.loadBot adapterPath, Options.adapter, Options.enableHttpd, Options.name, Options.alias
+  robot = Hubot.loadBot undefined, Options.adapter, Options.enableHttpd, Options.name, Options.alias
 
   if Options.version
     console.log robot.version

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -34,13 +34,15 @@ class Robot
   # Robots receive messages from a chat source (Campfire, irc, etc), and
   # dispatch them to matching listeners.
   #
-  # adapterPath - A String of the path to local adapters.
+  # adapterPath -  A String of the path to built-in adapters (defaults to src/adapters)
   # adapter     - A String of the adapter name.
   # httpd       - A Boolean whether to enable the HTTP daemon.
   # name        - A String of the robot name, defaults to Hubot.
   #
   # Returns nothing.
   constructor: (adapterPath, adapter, httpd, name = 'Hubot', alias = false) ->
+    @adapterPath ?= Path.join __dirname, "adapters"
+
     @name       = name
     @events     = new EventEmitter
     @brain      = new Brain @
@@ -62,7 +64,7 @@ class Robot
     else
       @setupNullRouter()
 
-    @loadAdapter adapterPath, adapter
+    @loadAdapter adapter
 
     @adapterName   = adapter
     @errorHandlers = []
@@ -452,12 +454,12 @@ class Robot
   # adapter - A String of the adapter name to use.
   #
   # Returns nothing.
-  loadAdapter: (path, adapter) ->
+  loadAdapter: (adapter) ->
     @logger.debug "Loading adapter #{adapter}"
 
     try
       path = if adapter in HUBOT_DEFAULT_ADAPTERS
-        "#{path}/#{adapter}"
+        "#{@adapterPath}/#{adapter}"
       else
         "hubot-#{adapter}"
 


### PR DESCRIPTION
Previously, adapterPath was determined in bin/hubot, and passed to index.coffee,
 and eventually passed ot the constructor in robot.coffee. This is used by Robot
to determine where to load builtin adapters from.

It also makes it hard to progmatically construct a robot without running bin/hubot,
since you'd need to find a way to figure out the path that the hubot module is installed.

This changes it so Robot will determine the adapterPath since it's relative to where
it live. The constructor still takes it as an option so it remains backward compatible
 to anything that might be specifying it.

This is work towards https://github.com/github/hubot/issues/858