### PR TITLE
[shell] don't color hubot responses green, to be more visible on light backgrounds

### DIFF
--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -17,7 +17,7 @@ historyPath = ".hubot_history"
 
 class Shell extends Adapter
   send: (envelope, strings...) ->
-    console.log chalk.green.bold("#{str}") for str in strings
+    console.log chalk.bold("#{str}") for str in strings
 
   emote: (envelope, strings...) ->
     @send envelope, "* #{str}" for str in strings


### PR DESCRIPTION
This is a possible fix for https://github.com/github/hubot/issues/1102

cc @glensc