### PR TITLE
Correct documentation & variable names of functions that take envelopes, not users

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -534,22 +534,22 @@ class Robot
   # Public: A helper send function which delegates to the adapter's send
   # function.
   #
-  # user    - A User instance.
-  # strings - One or more Strings for each message to send.
+  # envelope - A Object with message, room and user details.
+  # strings  - One or more Strings for each message to send.
   #
   # Returns nothing.
-  send: (user, strings...) ->
-    @adapter.send user, strings...
+  send: (envelope, strings...) ->
+    @adapter.send envelope, strings...
 
   # Public: A helper reply function which delegates to the adapter's reply
   # function.
   #
-  # user    - A User instance.
-  # strings - One or more Strings for each message to send.
+  # envelope - A Object with message, room and user details.
+  # strings  - One or more Strings for each message to send.
   #
   # Returns nothing.
-  reply: (user, strings...) ->
-    @adapter.reply user, strings...
+  reply: (envelope, strings...) ->
+    @adapter.reply envelope, strings...
 
   # Public: A helper send function to message a room that the robot is in.
   #
@@ -558,8 +558,8 @@ class Robot
   #
   # Returns nothing.
   messageRoom: (room, strings...) ->
-    user = { room: room }
-    @adapter.send user, strings...
+    envelope = { room: room }
+    @adapter.send envelope, strings...
 
   # Public: A wrapper around the EventEmitter API to make usage
   # semantically better.


### PR DESCRIPTION
Awhile back in hubot's history, adapters were changed to take an
'envelope' instead of a user or room object. The adapter class was
updated but not the robot functions that delegate to the adapter.

I noticed this when someone was adding a script using it, and I was checking the usage.