### PR TITLE
[Hubot-Adapter] Add Hubot-Wechat to the adapter-list.

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -50,6 +50,7 @@ to have yours added to the list:
 * [Typetalk](https://github.com/nulab/hubot-typetalk)
 * [VictorOps](https://github.com/victorops/hubot-victorops)
 * [Visual Studio Online](https://github.com/scrumdod/hubot-VSOnline)
+* [Weixin](https://github.com/KasperDeng/Hubot-WeChat)
 * [XMPP](https://github.com/markstory/hubot-xmpp)
 * [Yammer](https://github.com/athieriot/hubot-yammer)
 


### PR DESCRIPTION
I created a new adapter for hubot for the chinese popular IM app weixin (another name is wechat) which is created by Tencent.

The hubot-weixin-adapter is running very well, it serves us in lots of scenarios and makes lots of fun for us.
In order to get more idea/enhancement and being widely used in the world, we decided to contribute the source code.
The github repo is https://github.com/KasperDeng/Hubot-WeChat

Could you help update the [adapters.md](https://github.com/github/hubot/blob/master/docs/adapters.md) for the [page](https://hubot.github.com/docs/adapters/), to add this new hubot-weixin into the adapter list and link to our github repo? Thanks in advance.

The main contributors for this adapter are

* bumblebee team 
  - [Jeff Zhu](https://github.com/kfchu)
  - [Yinsong Ma](https://github.com/eyinsma)
  - [Kasper Deng](https://github.com/kasperdeng)

* [Shouxi Huang](https://github.com/hsx1612727380)
