### PR TITLE
Add websocket based Mattermost adapter

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -34,6 +34,7 @@ to have yours added to the list:
 * [Let's Chat](https://github.com/sdelements/hubot-lets-chat)
 * [Lingr](https://github.com/miyagawa/hubot-lingr)
 * [Mattermost](https://github.com/renanvicente/hubot-mattermost)
+* [Mattermost](https://github.com/loafoe/hubot-matteruser) - websocket
 * [QQ](https://github.com/xhan/qqbot)
 * [Partychat](https://github.com/iangreenleaf/hubot-partychat-hooks)
 * [Proxy](https://github.com/Hammertime38/hubot-proxy) - This adapter allows the base application to observe, handle, and control events sent to the proxied adapter, all defined in a config object at the root of the module.


### PR DESCRIPTION
This Mattermost Hubot adapter uses a websocket connection and acts as a real user on your team. 
It allows Hubot to be invited to public *and* private channels. It also supported direct messages.