### PR TITLE
fix typo

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -553,7 +553,7 @@ robot.respond /sleep it off/i, (res) ->
   msg.reply 'zzzzz'
 ```
 
-If the script needs to lookup user data, there are methods on `robot.brain` for looking up one or many users by id, name, or 'fuzzy' matching of name: `userForName`, `userForId`, `userForFuzzyName`, and `usersForFuzzyName`.
+If the script needs to lookup user data, there are methods on `robot.brain` for looking up one or many users by id, name, or 'fuzzy' matching of name: `userForName`, `userForId`, `userForFuzzyName`, and `usersForRawFuzzyName`.
 
 ```coffeescript
 module.exports = (robot) ->

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -553,7 +553,7 @@ robot.respond /sleep it off/i, (res) ->
   msg.reply 'zzzzz'
 ```
 
-If the script needs to lookup user data, there are methods on `robot.brain` for looking up one or many users by id, name, or 'fuzzy' matching of name: `userForName`, `userForId`, `userForFuzzyName`, and `usersForRawFuzzyName`.
+If the script needs to lookup user data, there are methods on `robot.brain` for looking up one or many users by id, name, or 'fuzzy' matching of name: `userForName`, `userForId`, `usersForFuzzyName`, and `usersForRawFuzzyName`.
 
 ```coffeescript
 module.exports = (robot) ->


### PR DESCRIPTION
`userForFuzzyName` doesn't seem to exist in `brain.coffee`.
What does exist are:
`usersForFuzzyName` (note plural) and `usersForRawFuzzyName`

Update docs accordingly.