### PR TITLE
Add link to Skype Bot Platform adapter

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -44,6 +44,7 @@ to have yours added to the list:
 * [Skype](https://github.com/netpro2k/hubot-skype)
 * [SkypeWeb](https://github.com/sdimkov/hubot-skype-web)
 * [Skyweb](https://github.com/EllisV/hubot-skyweb)
+* [SkypeBots](https://github.com/ivadim/hubot-skypebots) - Using official skype bot api
 * [Talker](https://github.com/unixcharles/hubot-talker)
 * [Telegram](https://github.com/lukefx/hubot-telegram)
 * [Twilio IP Messaging](https://github.com/philnash/hubot-twilio-ip-messaging)


### PR DESCRIPTION
Hello I'm a developer of https://github.com/ivadim/hubot-skypebots adapter for Skype. 
This adapter is using new Bots API provided by Skype (http://blogs.skype.com/2016/03/30/skype-bots-preview-comes-to-consumers-and-developers/).
