### PR TITLE
Doc improvement

### DIFF
--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -3,7 +3,7 @@ permalink: /docs/deploying/azure/index.html
 layout: docs
 ---
 
-If you've been following along with [Getting Started](../index.md), it's time to deploy so you can use it beyond just your local machine.
+If you've been following along with [Getting Started](/docs/index.md), it's time to deploy so you can use it beyond just your local machine.
 [Azure](http://azure.microsoft.com/) is a way to deploy hubot as an alternative to [Heroku](/docs/deploying/heroku.md).
 
 You will need to install the azure-cli via npm after you have follow the initial instructions for your hubot.

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -42,6 +42,10 @@ Now, create a new file in the base directory of hubot called `server.js` and put
     require('coffee-script/register');
     module.exports = require('hubot/bin/hubot.coffee');
 
+Install coffee-script package.
+
+    npm install coffee-script --save
+
 Finally you will need to add the environment variables to the website to make sure it runs properly. You can either do it through the GUI (under configuration) or you can use the Azure PowerShell command line, as follows (example is showing slack as an adapter and mynewhubot as the website name).
 
     % $settings = New-Object Hashtable

--- a/docs/deploying/bluemix.md
+++ b/docs/deploying/bluemix.md
@@ -3,7 +3,7 @@ permalink: /docs/deploying/bluemix/index.html
 layout: docs
 ---
 
-If you've been following along with [Getting Started](../index.md), it's time
+If you've been following along with [Getting Started](/docs/index.md), it's time
 to deploy so you can use it beyond just your local machine.
 [IBM Bluemix](http://bluemix.net) is a way to deploy hubot as an alternative to
 [Heroku](/docs/deploying/heroku.md). It is built on the open-source project

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,8 @@ You can deploy hubot to Heroku, which is the officially supported method.
 Additionally you are able to deploy hubot to a UNIX-like system or Windows.
 Please note the support for deploying to Windows isn't officially supported.
 
+* [Deploying Hubot onto Azure](/docs/deploying/azure.md)
+* [Deploying Hubot onto Bluemix](/docs/deploying/bluemix.md)
 * [Deploying Hubot onto Heroku](/docs/deploying/heroku.md)
 * [Deploying Hubot onto UNIX](/docs/deploying/unix.md)
 * [Deploying Hubot onto Windows](/docs/deploying/windows.md)


### PR DESCRIPTION
It changes to work on the web site, too. Currently, you get 404 error.
https://hubot.github.com/docs/deploying/azure/

The bug included PR
#1148

Add more information to install coffee-script package for azure
