### PR TITLE
Make shell history file secure by default

### DIFF
--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -64,7 +64,8 @@ class Shell extends Adapter
         startIndex = history.length - historySize
         history = history.reverse().splice(startIndex, historySize)
 
-        outstream = fs.createWriteStream(historyPath)
+        fileOpts = { mode:0o600 }
+        outstream = fs.createWriteStream(historyPath, fileOpts)
         # >= node 0.10
         outstream.on 'finish', () =>
           @shutdown()


### PR DESCRIPTION
Change the default file mode from `0o666` (u=rw,g=rw,o=rw) to `0o600` (u=rw,go=), which will deny access to everyone else other than the owner of the file.
This is used only when creating the file, so the user can change it afterwards if really want to make it public.
