### PR TITLE
docs: add link to symphony adapater

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -44,6 +44,7 @@ to have yours added to the list:
 * [Skype](https://github.com/netpro2k/hubot-skype)
 * [SkypeWeb](https://github.com/sdimkov/hubot-skype-web)
 * [Skyweb](https://github.com/EllisV/hubot-skyweb)
+* [Symphony](https://github.com/symphonyoss/hubot-symphony)
 * [Talker](https://github.com/unixcharles/hubot-talker)
 * [Telegram](https://github.com/lukefx/hubot-telegram)
 * [Twilio IP Messaging](https://github.com/philnash/hubot-twilio-ip-messaging)


### PR DESCRIPTION
Updating the adapter list as per https://github.com/github/hubot/issues/1216
