### PR TITLE
Clearer README on what hubot really is

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hubot
 
-Hubot is a chat bot, modeled after GitHub's Campfire bot, hubot. He's pretty
-cool. He's [extendable with scripts](http://hubot.github.com/docs/#scripts) and can work on [many
-different chat services](https://hubot.github.com/docs/adapters/).
+Hubot is a framework to build chat bots, modeled after GitHub's Campfire bot of the same name, hubot. 
+He's pretty cool. He's [extendable with scripts](http://hubot.github.com/docs/#scripts) and can work 
+on [many different chat services](https://hubot.github.com/docs/adapters/).
 
 This repository provides a library that's distributed by `npm` that you
 use for building your own bots.  See the [documentation](http://hubot.github.com/docs)
@@ -11,7 +11,7 @@ for details on getting up and running with your very own robot friend.
 In most cases, you'll probably never have to hack on this repo directly if you
 are building your own bot. But if you do, check out [CONTRIBUTING.md](CONTRIBUTING.md)
 
-If you'd like to chat, drop by [#hubot](http://webchat.freenode.net/?channels=#hubot) on FreeNode IRC.
+If you'd like to chat with Hubot users and developers, drop by #hubot on FreeNode IRC.
 
 ## License
 


### PR DESCRIPTION
.. and removing the link to webchat will avoid misleading visitors. In the past 6 months, people just jump in, expect to be able to test a bot, and don't stay. But there is no bot on that irc channel, as it's more a social place for developers ...

I hope this change in the README could improve the quality of our irc channel :)