### PR TITLE
closes http server on robot.shutdown()

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -596,6 +596,7 @@ class Robot
     clearInterval @pingIntervalId if @pingIntervalId?
     process.removeListener 'uncaughtException', @onUncaughtException
     @adapter.close()
+    @server.close() if @server
     @brain.close()
 
   # Public: The version of Hubot from npm

--- a/test/middleware_test.coffee
+++ b/test/middleware_test.coffee
@@ -334,7 +334,6 @@ describe 'Middleware', ->
       @testListener = @robot.listeners[0]
 
     afterEach ->
-      @robot.server.close()
       @robot.shutdown()
 
     describe 'listener middleware context', ->

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -46,7 +46,6 @@ describe 'Robot', ->
     }
 
   afterEach ->
-   @robot.server.close()
    @robot.shutdown()
 
   describe 'Unit Tests', ->


### PR DESCRIPTION
... and removes @robot.server.close() from afterEach hooks.

While testing my hubot scripts' express routes, I noticed that a robot created in a before-hook with enabled http does not shut down the http server on `robot.shutdown()`. 

I know that there are discussions to pull out the express server as a module/script, but in the meantime, this would fix the _issue_, if you want to call it one.

I also removed the explicit `@robot.server.close()` calls in 2 test files, as calling `close()` multiple times on an http server seems to throw an error in node v0.10.