### PR TITLE
Make all documentation links relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,7 @@
 - Upgrade express to v3.21.2 [\#1119](https://github.com/github/hubot/pull/1119) ([sgerrand](https://github.com/sgerrand))
 - Fixed link to getting started [\#1116](https://github.com/github/hubot/pull/1116) ([jackmawer](https://github.com/jackmawer))
 - Fix http and https documentation [\#1114](https://github.com/github/hubot/pull/1114) ([technicalpickles](https://github.com/technicalpickles))
-- \[shell\] don't color hubot responses green, to be more visible on light backgrounds [\#1111](https://github.com/github/hubot/pull/1111) ([technicalpickles](https://g
-ithub.com/technicalpickles))
+- \[shell\] don't color hubot responses green, to be more visible on light backgrounds [\#1111](https://github.com/github/hubot/pull/1111) ([technicalpickles](https://github.com/technicalpickles))
 - Determine adapterPath in robot.coffee, rather than bin/hubot [\#1109](https://github.com/github/hubot/pull/1109) ([technicalpickles](https://github.com/technicalpickl
 es))
 - Updated copyright to 2016 [\#1103](https://github.com/github/hubot/pull/1103) ([aqnouch](https://github.com/aqnouch))

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/adapters/
-layout: docs
 ---
 
 Adapters are the interface to the service you want your hubot to run on.

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/adapters/index.html
+permalink: /docs/adapters/
 layout: docs
 ---
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -10,8 +10,8 @@ Adapters are the interface to the service you want your hubot to run on.
 
 Hubot includes two official adapters:
 
-* [Shell](/docs/adapters/shell.md), i.e. for use with development
-* [Campfire](/docs/adapters/campfire.md)
+* [Shell](./adapters/shell.md), i.e. for use with development
+* [Campfire](./adapters/campfire.md)
 
 ## Third-party Adapters
 
@@ -59,4 +59,4 @@ to have yours added to the list:
 
 ## Writing Your Own Adapter
 
-Interested in adding your own adapter? Check out our documentation for [developing adapters](/docs/adapters/development.md)
+Interested in adding your own adapter? Check out our documentation for [developing adapters](./adapters/development.md)

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -2,6 +2,8 @@
 permalink: /docs/adapters/
 ---
 
+# Adapters
+
 Adapters are the interface to the service you want your hubot to run on.
 
 ## Official Adapters

--- a/docs/adapters/campfire.md
+++ b/docs/adapters/campfire.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/adapters/campfire/
-layout: docs
 ---
 
 [Campfire](http://campfirenow.com/) is a web based chat application built by

--- a/docs/adapters/campfire.md
+++ b/docs/adapters/campfire.md
@@ -17,7 +17,7 @@ Next, you will need to create a user on your Campfire account for your Hubot,
 then give it access so it can join to your rooms. You will need to create a room
 if you haven't already.
 
-Hubot defaults to using its [shell](/docs/adapters/shell.md), so to use Campfire instead, you
+Hubot defaults to using its [shell](./shell.md), so to use Campfire instead, you
 can run hubot with `-a campfire`:
 
     % bin/hubot -a campfire

--- a/docs/adapters/campfire.md
+++ b/docs/adapters/campfire.md
@@ -2,6 +2,8 @@
 permalink: /docs/adapters/campfire/
 ---
 
+# Campfire adapter
+
 [Campfire](http://campfirenow.com/) is a web based chat application built by
 [37signals](http://37signals.com). The Campfire adapter is one of the original
 adapters in Hubot.

--- a/docs/adapters/campfire.md
+++ b/docs/adapters/campfire.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/adapters/campfire/index.html
+permalink: /docs/adapters/campfire/
 layout: docs
 ---
 

--- a/docs/adapters/development.md
+++ b/docs/adapters/development.md
@@ -2,7 +2,9 @@
 permalink: /docs/adapters/development/
 ---
 
-# Adapter Basics
+# Development adapter
+
+## Adapter Basics
 
 All adapters inherit from the Adapter class in the `src/adapter.coffee` file.  There are certain methods that you will want to override.  Here is a basic stub of what an extended Adapter class would look like:
 
@@ -31,7 +33,7 @@ exports.use = (robot) ->
   new Sample robot
 ```
 
-# Setting Up Your Development Environment
+## Setting Up Your Development Environment
 
 1. Create a new folder for your adapter `hubot-sample`
   - `mkdir hubot-sample`
@@ -60,7 +62,7 @@ exports.use = (robot) ->
   - `npm link ../hubot-sample`
 10. Run `hubot -a sample`
 
-# Gotchas
+## Gotchas
 
 There is a an open issue in the node community around [npm linked peer dependencies not working](https://github.com/npm/npm/issues/5875).  To get this working for our project you will need to do some minor changes to your code.
 

--- a/docs/adapters/development.md
+++ b/docs/adapters/development.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-permalink: /docs/adapters/development/index.html
+permalink: /docs/adapters/development/
 ---
 
 # Adapter Basics
@@ -54,7 +54,7 @@ exports.use = (robot) ->
     "coffee-script": ">=1.2.0"
   }
   ```
-  
+
 7. Generate your Hubot using the `yo hubot` [command](https://hubot.github.com/docs/)
 8. Change working directories to the `hubot` you created in step 7.
 9. Now perform an `npm link` to add your adapter to `hubot`

--- a/docs/adapters/development.md
+++ b/docs/adapters/development.md
@@ -1,5 +1,4 @@
 ---
-layout: docs
 permalink: /docs/adapters/development/
 ---
 

--- a/docs/adapters/shell.md
+++ b/docs/adapters/shell.md
@@ -2,6 +2,8 @@
 permalink: /docs/adapters/shell/
 ---
 
+# Shell adapter
+
 The shell adapter provides a simple read-eval-print loop for interacting with a hubot locally.
 It can be useful for testing scripts before using them on a live hubot.
 

--- a/docs/adapters/shell.md
+++ b/docs/adapters/shell.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/adapters/shell/
-layout: docs
 ---
 
 The shell adapter provides a simple read-eval-print loop for interacting with a hubot locally.

--- a/docs/adapters/shell.md
+++ b/docs/adapters/shell.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/adapters/shell/index.html
+permalink: /docs/adapters/shell/
 layout: docs
 ---
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -2,6 +2,8 @@
 permalink: /docs/deploying/
 ---
 
+# Deploying
+
 - [Azure](/docs/deploying/azure.md)
 - [Bluemix](/docs/deploying/bluemix.md)
 - [Heroku](/docs/deploying/heroku.md)

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -4,8 +4,8 @@ permalink: /docs/deploying/
 
 # Deploying
 
-- [Azure](/docs/deploying/azure.md)
-- [Bluemix](/docs/deploying/bluemix.md)
-- [Heroku](/docs/deploying/heroku.md)
-- [Unix](/docs/deploying/unix.md)
-- [Windows](/docs/deploying/windows.md)
+- [Azure](./deploying/azure.md)
+- [Bluemix](./deploying/bluemix.md)
+- [Heroku](./deploying/heroku.md)
+- [Unix](./deploying/unix.md)
+- [Windows](./deploying/windows.md)

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/deploying/index.html
+permalink: /docs/deploying/
 layout: docs
 ---
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/deploying/
-layout: docs
 ---
 
 - [Azure](/docs/deploying/azure.md)

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -5,7 +5,7 @@ permalink: /docs/deploying/azure/
 # Deploying to Azure
 
 If you've been following along with [Getting Started](../index.md), it's time to deploy so you can use it beyond just your local machine.
-[Azure](http://azure.microsoft.com/) is a way to deploy hubot as an alternative to [Heroku](/docs/deploying/heroku.md).
+[Azure](http://azure.microsoft.com/) is a way to deploy hubot as an alternative to [Heroku](heroku.md).
 
 You will need to install the azure-cli via npm after you have follow the initial instructions for your hubot.
 
@@ -70,7 +70,7 @@ Finally, add two more environment variables to your website. You can do this eit
     % $settings["HUBOT_BRAIN_AZURE_STORAGE_ACCESS_KEY"] = "your Azure storage account key"
     % Set-AzureWebsite -AppSettings $settings mynewhubot
 
-Now any scripts that require a brain will function. You should look up other scripts or write your own by looking at the [documentation](/docs/scripting.md). All of the normal scripts for hubot are compatible with hosting hubot on Azure.
+Now any scripts that require a brain will function. You should look up other scripts or write your own by looking at the [documentation](../scripting.md). All of the normal scripts for hubot are compatible with hosting hubot on Azure.
 
 ### Troubleshooting tips and tricks
 

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/deploying/azure/index.html
+permalink: /docs/deploying/azure/
 layout: docs
 ---
 

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -2,6 +2,8 @@
 permalink: /docs/deploying/azure/
 ---
 
+# Deploying to Azure
+
 If you've been following along with [Getting Started](../index.md), it's time to deploy so you can use it beyond just your local machine.
 [Azure](http://azure.microsoft.com/) is a way to deploy hubot as an alternative to [Heroku](/docs/deploying/heroku.md).
 

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/deploying/azure/
-layout: docs
 ---
 
 If you've been following along with [Getting Started](../index.md), it's time to deploy so you can use it beyond just your local machine.

--- a/docs/deploying/bluemix.md
+++ b/docs/deploying/bluemix.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/deploying/bluemix/
-layout: docs
 ---
 
 If you've been following along with [Getting Started](../index.md), it's time

--- a/docs/deploying/bluemix.md
+++ b/docs/deploying/bluemix.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/deploying/bluemix/index.html
+permalink: /docs/deploying/bluemix/
 layout: docs
 ---
 

--- a/docs/deploying/bluemix.md
+++ b/docs/deploying/bluemix.md
@@ -2,6 +2,8 @@
 permalink: /docs/deploying/bluemix/
 ---
 
+# Deploying to Bluemix
+
 If you've been following along with [Getting Started](../index.md), it's time
 to deploy so you can use it beyond just your local machine.
 [IBM Bluemix](http://bluemix.net) is a way to deploy hubot as an alternative to

--- a/docs/deploying/bluemix.md
+++ b/docs/deploying/bluemix.md
@@ -7,7 +7,7 @@ permalink: /docs/deploying/bluemix/
 If you've been following along with [Getting Started](../index.md), it's time
 to deploy so you can use it beyond just your local machine.
 [IBM Bluemix](http://bluemix.net) is a way to deploy hubot as an alternative to
-[Heroku](/docs/deploying/heroku.md). It is built on the open-source project
+[Heroku](heroku.md). It is built on the open-source project
 [Cloud Foundry](https://www.cloudfoundry.org/), so we'll be using the `cf cli`
 throughout these examples.
 

--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/deploying/heroku/
-layout: docs
 ---
 
 If you've been following along with [Getting Started](../index.md), it's time to deploy so you can use it beyond just your local machine.

--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -2,6 +2,8 @@
 permalink: /docs/deploying/heroku/
 ---
 
+# Deploying to Heroku
+
 If you've been following along with [Getting Started](../index.md), it's time to deploy so you can use it beyond just your local machine.
 [Heroku](http://www.heroku.com/) is an easy and supported way to deploy hubot.
 

--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/deploying/heroku/index.html
+permalink: /docs/deploying/heroku/
 layout: docs
 ---
 

--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -33,7 +33,7 @@ Then create a Heroku application:
 
 Before you deploy the application, you'll need to configure some environment
 variables for hubot to use. The specific variables you'll need depends on which
-[adapter](/docs/adapters.md) and scripts you are using. For Campfire, with no other
+[adapter](../adapters.md) and scripts you are using. For Campfire, with no other
 scripts, you'd need to set the following environment variables:
 
     % heroku config:set HUBOT_CAMPFIRE_ACCOUNT=yourcampfireaccount

--- a/docs/deploying/unix.md
+++ b/docs/deploying/unix.md
@@ -2,6 +2,8 @@
 permalink: /docs/deploying/unix/
 ---
 
+# Deploying to Unix
+
 Because there are so many variations of Linux, and more generally UNIX, it's
 difficult for the hubot team to have canonical documentation for installing and
 deploying it to every version out there. So, this is an attempt to give an

--- a/docs/deploying/unix.md
+++ b/docs/deploying/unix.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/deploying/unix/
-layout: docs
 ---
 
 Because there are so many variations of Linux, and more generally UNIX, it's

--- a/docs/deploying/unix.md
+++ b/docs/deploying/unix.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/deploying/unix/index.html
+permalink: /docs/deploying/unix/
 layout: docs
 ---
 

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -2,6 +2,8 @@
 permalink: /docs/deploying/windows/
 ---
 
+# Deploying to Windows
+
 Hasn't been fully tested - YMMV
 
 There are 4 primary steps to deploying and running hubot on a Windows machine:

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/deploying/windows/
-layout: docs
 ---
 
 Hasn't been fully tested - YMMV

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -23,7 +23,7 @@ Your other option is to install directly from [NodeJS](https://nodejs.org/) and 
 
 ## Updating code on the server
 
-To get the code on your server, you can follow the instructions at [Getting Started](/docs/index.md) on your local development machine or directly on the server. If you are building locally, push your hubot to GitHub and clone the repo onto your server. Don't clone the normal [github/hubot repository](http://github.com/github/hubot), make sure you're using the Yo Generator to build your own hubot.
+To get the code on your server, you can follow the instructions at [Getting Started](../index.md) on your local development machine or directly on the server. If you are building locally, push your hubot to GitHub and clone the repo onto your server. Don't clone the normal [github/hubot repository](http://github.com/github/hubot), make sure you're using the Yo Generator to build your own hubot.
 
 ## Setting up environment vars
 
@@ -46,7 +46,7 @@ There are a few issues if you call it manually, though.
 * hubot dies, for any reason, and doesn't start again
 * it doesn't start up at boot automatically
 
-To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. There is a copy of this file in the `examples` directory [here](/examples/hubot-start.ps1). It should contain the following:
+To fix this, you will want to create a .ps1 file with whatever name makes you happy that you will call from your hubot directory. There is a copy of this file in the `examples` directory [here](../../examples/hubot-start.ps1). It should contain the following:
 
     Write-Host "Starting Hubot Watcher"
     While (1)

--- a/docs/deploying/windows.md
+++ b/docs/deploying/windows.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/deploying/windows/index.html
+permalink: /docs/deploying/windows/
 layout: docs
 ---
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -3,6 +3,8 @@ title: Implementation Notes
 permalink: /docs/implementation/
 ---
 
+# Implementation
+
 For the purpose of maintainability, several internal flows are documented here.
 
 ## Message Processing

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,7 +1,6 @@
 ---
 title: Implementation Notes
 permalink: /docs/implementation/
-layout: docs
 ---
 
 For the purpose of maintainability, several internal flows are documented here.

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,6 +1,6 @@
 ---
 title: Implementation Notes
-permalink: /docs/implementation/index.html
+permalink: /docs/implementation/
 layout: docs
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ we wanted to make a bot called myhubot:
     % yo hubot
 
 At this point, you'll be asked a few questions about who is creating the bot,
-and which [adapter](/docs/adapters.md) you'll be using. Adapters are hubot's
+and which [adapter](adapters.md) you'll be using. Adapters are hubot's
 way of integrating with different chat providers.
 
 If you are using git, the generated directory includes a .gitignore, so you can
@@ -49,7 +49,7 @@ Hubot needs Redis to persist data, so before you can start hubot on your own com
     % bin/hubot
     Hubot>
 
-This starts hubot using the [shell adapter](/docs/adapters/shell.md), which
+This starts hubot using the [shell adapter](./adapters/shell.md), which
 is mostly useful for development. Make note of  `Hubot>`; this is the name your hubot will
 `respond` to with commands. For example, to list available commands:
 
@@ -107,11 +107,11 @@ To use a script from an NPM package:
 2. Add the package to `external-scripts.json`.
 3. Run `npm home <package-name>` to open a browser window for the homepage of the script, where you can find more information about configuring and installing the script.
 
-You can also put your own scripts under the `scripts/` directory. All scripts placed there are automatically loaded and ready to use with your hubot. Read more about customizing hubot by [writing your own scripts](/docs/scripting.md).
+You can also put your own scripts under the `scripts/` directory. All scripts placed there are automatically loaded and ready to use with your hubot. Read more about customizing hubot by [writing your own scripts](scripting.md).
 
 ## Adapters
 
-Hubot uses the adapter pattern to support multiple chat-backends. Here is a [list of available adapters](/docs/adapters.md), along with details on how to configure them.
+Hubot uses the adapter pattern to support multiple chat-backends. Here is a [list of available adapters](adapters.md), along with details on how to configure them.
 
 ## Deploying
 
@@ -119,10 +119,10 @@ You can deploy hubot to Heroku, which is the officially supported method.
 Additionally you are able to deploy hubot to a UNIX-like system or Windows.
 Please note the support for deploying to Windows isn't officially supported.
 
-* [Deploying Hubot onto Heroku](/docs/deploying/heroku.md)
-* [Deploying Hubot onto UNIX](/docs/deploying/unix.md)
-* [Deploying Hubot onto Windows](/docs/deploying/windows.md)
+* [Deploying Hubot onto Heroku](./deploying/heroku.md)
+* [Deploying Hubot onto UNIX](./deploying/unix.md)
+* [Deploying Hubot onto Windows](./deploying/windows.md)
 
 ## Patterns
 
-Using custom scripts, you can quickly customize Hubot to be the most life embettering robot he or she can be. Read [docs/patterns.md](/docs/patterns.md) for some nifty tricks that may come in handy as you teach your hubot new skills.
+Using custom scripts, you can quickly customize Hubot to be the most life embettering robot he or she can be. Read [docs/patterns.md](patterns.md) for some nifty tricks that may come in handy as you teach your hubot new skills.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 ---
 title: Hubot
 permalink: /docs/
-layout: docs
 ---
 
 ## Getting Started With Hubot

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hubot
-permalink: /docs/index.html
+permalink: /docs/
 layout: docs
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-title: Hubot
 permalink: /docs/
 ---
 
@@ -33,13 +32,13 @@ If you'd prefer to automate your hubot build without being interactively
 prompted for its configuration, you can add the following options
 to the `yo hubot` command to do so:
 
-| Option                                      | Description
-| ------------------------------------------- | -----------------------------------------------------
-| `--owner="Bot Wrangler <bw@example.com>"`   | Bot owner, e.g. "Bot Wrangler <bw@example.com>"
-| `--name="Hubot"`                            | Bot name, e.g. "Hubot"
-| `--description="Delightfully aware robutt"` | Bot description, e.g. "Delightfully aware robutt"
-| `--adapter=campfire`                        | Bot adapter, e.g. "campfire"
-| `--defaults`                                | Declare all defaults are set and no prompting required
+| Option                                      | Description                                            |
+|:--------------------------------------------|:-------------------------------------------------------|
+| `--owner="Bot Wrangler <bw@example.com>"`   | Bot owner, e.g. "Bot Wrangler <bw@example.com>"        |
+| `--name="Hubot"`                            | Bot name, e.g. "Hubot"                                 |
+| `--description="Delightfully aware robutt"` | Bot description, e.g. "Delightfully aware robutt"      |
+| `--adapter=campfire`                        | Bot adapter, e.g. "campfire"                           |
+| `--defaults`                                | Declare all defaults are set and no prompting required |
 
 You now have your own functional hubot! There's a `bin/hubot`
 command for convenience, to handle installing npm dependencies, loading scripts,

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -15,7 +15,7 @@ When you rename Hubot, he will no longer respond to his former name. In order to
 
 Setting this up is very easy:
 
-1. Create a [bundled script](/docs/scripting.md) in the `scripts/` directory of your Hubot instance called `rename-hubot.coffee`
+1. Create a [bundled script](scripting.md) in the `scripts/` directory of your Hubot instance called `rename-hubot.coffee`
 2. Add the following code, modified for your needs:
 
 ```coffeescript
@@ -73,7 +73,7 @@ In many corporate environments, a web proxy is required to access the Internet a
 Due to the way node.js handles HTTP and HTTPS requests, you need to specify a different Agent for each protocol. ScopedHTTPClient will then automatically choose the right ProxyAgent for each request.
 
 1. Install ProxyAgent. `npm install proxy-agent`
-2. Create a [bundled script](/docs/scripting.md) in the `scripts/` directory of your Hubot instance called `proxy.coffee`
+2. Create a [bundled script](scripting.md) in the `scripts/` directory of your Hubot instance called `proxy.coffee`
 3. Add the following code, modified for your needs:
 
 ```coffeescript

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -2,6 +2,8 @@
 permalink: /docs/patterns/
 ---
 
+# Patterns
+
 Shared patterns for dealing with common Hubot scenarios.
 
 ## Renaming the Hubot instance

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/patterns/index.html
+permalink: /docs/patterns/
 layout: docs
 ---
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/patterns/
-layout: docs
 ---
 
 Shared patterns for dealing with common Hubot scenarios.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -2,6 +2,8 @@
 permalink: /docs/scripting/
 ---
 
+# Scripting
+
 Hubot out of the box doesn't do too much but it is an extensible, scriptable robot friend. There are [hundreds of scripts written and maintained by the community](/docs/#scripts.md) and it's easy to write your own.  You can create a custom script in hubot's `scripts` directory or [create a script package](#creating-a-script-package) for sharing with the community!
 
 ## Anatomy of a script

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -4,7 +4,7 @@ permalink: /docs/scripting/
 
 # Scripting
 
-Hubot out of the box doesn't do too much but it is an extensible, scriptable robot friend. There are [hundreds of scripts written and maintained by the community](/docs/#scripts.md) and it's easy to write your own.  You can create a custom script in hubot's `scripts` directory or [create a script package](#creating-a-script-package) for sharing with the community!
+Hubot out of the box doesn't do too much but it is an extensible, scriptable robot friend. There are [hundreds of scripts written and maintained by the community](index.md#scripts) and it's easy to write your own.  You can create a custom script in hubot's `scripts` directory or [create a script package](#creating-a-script-package) for sharing with the community!
 
 ## Anatomy of a script
 
@@ -590,7 +590,7 @@ Once you've built some new scripts to extend the abilities of your robot friend,
 
 ## See if a script already exists
 
-Start by [checking if an NPM package](/docs/index.md#scripts) for a script like yours already exists.  If you don't see an existing package that you can contribute to, then you can easily get started using the `hubot` script [yeoman](http://yeoman.io/) generator.
+Start by [checking if an NPM package](index.md#scripts) for a script like yours already exists.  If you don't see an existing package that you can contribute to, then you can easily get started using the `hubot` script [yeoman](http://yeoman.io/) generator.
 
 ## Creating A Script Package
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -1,5 +1,5 @@
 ---
-permalink: /docs/scripting/index.html
+permalink: /docs/scripting/
 layout: docs
 ---
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -1,6 +1,5 @@
 ---
 permalink: /docs/scripting/
-layout: docs
 ---
 
 Hubot out of the box doesn't do too much but it is an extensible, scriptable robot friend. There are [hundreds of scripts written and maintained by the community](/docs/#scripts.md) and it's easy to write your own.  You can create a custom script in hubot's `scripts` directory or [create a script package](#creating-a-script-package) for sharing with the community!


### PR DESCRIPTION
With the goal of making the documentation readable on both GitHub.com and GitHub Pages, this pull request updates the Hubot documentation to use relative, rather than absolute links to link to one markdown file from another (e.g., from `/docs/index.md`, `scripts.md` or `./scripts.md` instead of `/docs/scripts.md).

Additionally, I added Markdown titles to each document to improve readability. There should be no substantive changes.
