### PR TITLE
Add links to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hubot
 
-Hubot is a framework to build chat bots, modeled after GitHub's Campfire bot of the same name, hubot. 
-He's pretty cool. He's [extendable with scripts](http://hubot.github.com/docs/#scripts) and can work 
+Hubot is a framework to build chat bots, modeled after GitHub's Campfire bot of the same name, hubot.
+He's pretty cool. He's [extendable with scripts](http://hubot.github.com/docs/#scripts) and can work
 on [many different chat services](https://hubot.github.com/docs/adapters/).
 
 This repository provides a library that's distributed by `npm` that you
@@ -11,7 +11,7 @@ for details on getting up and running with your very own robot friend.
 In most cases, you'll probably never have to hack on this repo directly if you
 are building your own bot. But if you do, check out [CONTRIBUTING.md](CONTRIBUTING.md)
 
-If you'd like to chat with Hubot users and developers, drop by #hubot on FreeNode IRC.
+If you'd like to chat with Hubot users and developers, [join us on Slack](https://hubot-slackin.herokuapp.com/).
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ This roadmap represents some of priorities for us over the next couple months. I
 
 - [ ] Consolidate all officially supported Hubot projects into a single GitHub organization. This will include github/hubot and a handful of supported scripts, but will not include all community scripts in https://github.com/hubot-scripts
 - [ ] Create a community forum to provide a place for people to ask questions, get help, and share best practices. [Discourse](https://www.discourse.org/) is the obvious choice here.
-- [ ] Choose a chat platform for maintainers and contributors, and post notices in various existing places (#hubot on freenode, github/hubot on Gitter). Slack is the obvious choice here.
+- [x] Choose a chat platform for maintainers and contributors, and post notices in various existing places (#hubot on freenode, github/hubot on Gitter). Slack is the obvious choice here. [Join us on Slack](https://hubot-slackin.herokuapp.com/).
 - [ ] Add a code of conduct based on http://contributor-covenant.org/ and processes to enforce it in all official spaces.
 - [ ] Publish weekly community updates (blog, newsletter, etc) which highlight recent and upcoming changes, give shoutouts to contributors / maintainers, and maybe mention interesting uses of Hubot
 - [ ] Create Hubot Evolution—inspired by [Swift Evolution](https://github.com/apple/swift-evolution)—for proposing user-visible enhancements. This roadmap will be moved there and all future proposals will follow the process laid out in that repository.


### PR DESCRIPTION
This adds links to our shiny new Slack account to the README.

Closes #1322 