### PR TITLE
Add a new / updated generator to the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@ This roadmap represents some of priorities for us over the next couple months. I
 Each of these proposals will go through the “Hubot Evolution” process.
 
 - [ ] Translate from CoffeeScript to JavaScript and update to modern versions of Node.js and NPM (or Yarn)
+- [ ] Revisit new bot generator (yeoman has a ton of dependencies, some of which can be error prone on windows)
 - [ ] Support for running multiple adapters and archetypes (chat, deployment, CI, github, etc)
 - [ ] Merge with [@probot](https://github.com/probot) and build out first class GitHub integration.
 - [ ] Introduce "Commands”, an explicit interface for registering commands (like Slack’s slash commands) as an alternative to regular expressions


### PR DESCRIPTION
It seemed like a good idea at the time, but the generator at https://github.com/github/generator-hubot is a bit of a maintenance headache. Previously, it was just part of the hubot package and just dropped files on disks without a 'real' generator.

https://github.com/github/generator-hubot/issues has some of the current issue, but I have also seen in the past lots of issues with just installing `yeoman`, since it has a ton of dependencies.

I'm not picky about where on the roadmap it is, but it should go somewhere.

cc @bkeepers @mose