### PR TITLE
Add config for probot stale plugin

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 7
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking as stale
+staleLabel: stale
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+# only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,9 +12,9 @@ exemptLabels:
 staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  This issue has been automatically marked as stale because it has [not had
+  recent activity](https://github.com/github/hubot/blob/master/CONTRIBUTING.md#stale-issue-and-pull-request-policy).
+  It will be closed if no further activity occurs. Thank you for your contributions.
 # Comment to post when removing the stale label. Set to `false` to disable
 unmarkComment: false
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Syntax:
   * `a = b` and not `a=b`.
   * Follow the conventions you see used in the source already.
 
-# Stale Issue & Pull Request Policy
+# Stale issue and pull request policy
 
 Issues and pull requests have a shelf life and sometimes they are no longer relevant. All issues and pull requests that have not had any activity for 90 days will be marked as `stale`. Simply leave a comment with information about why it may still be relevant to keep it open. If no activity occurs in the next 7 days, it will be automatically closed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ Syntax:
   * `a = b` and not `a=b`.
   * Follow the conventions you see used in the source already.
 
+# Stale Issue & Pull Request Policy
+
+Issues and pull requests have a shelf life and sometimes they are no longer relevant. All issues and pull requests that have not had any activity for 90 days will be marked as `stale`. Simply leave a comment with information about why it may still be relevant to keep it open. If no activity occurs in the next 7 days, it will be automatically closed.
+
+The goal of this process is to keep the list of open issues and pull requests focused on work that is actionable and important for the maintainers and the community.
+
 # Releasing
 
 This section is for maintainers of hubot. Here's the current process for releasing:


### PR DESCRIPTION
This adds config for the @probot plugin that [closes stale issues and PRs](https://github.com/probot/stale). There are currently [75 issues/PRs that will be marked stale](https://github.com/github/hubot/search?utf8=%E2%9C%93&q=updated%3A%3C2017-02-18+is%3Aopen&type=Issues).

I know @mose has been working through open issues & PRs, but how does everyone feel if we install this now and let the bot do most of the work so we're only left with things that are still affecting people?

- [x] Get 👍  on the [config](https://github.com/github/hubot/blob/stale/.github/stale.yml)
- [x] Decide when to ship it
- [x] :shipit: 
- [x] [Install the integration](https://github.com/integration/probot-stale)