### PR TITLE
Update node versions that Travis runs against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
-
-matrix:
-  include:
-    - node_js: "0.10"
-    - node_js: "0.12"
-    - node_js: "4"
-    - node_js: "5"
+node_js:
+  - "node" # latest stable Node.js release
+  - "7"
+  - "6"
+  - "5"
+  - "4"
+  - "0.12"
 notifications:
   email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "5"
   - "4"
   - "0.12"
+  - "0.10"
 notifications:
   email: false
 sudo: false


### PR DESCRIPTION
It looks like the Travis builds got deactivated at some point. I turned them back on, and while I'm at it, am updating the versions of node that it tests against.

Changes:

- ~~Drop `0.10` (`0.12` is still supported)~~
- Add `6`, `7`, and `node` for latest stable release