### PR TITLE
Add evolution to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing
 
-This project adheres to the [Contributor Covenant Code of Conduct](http://contributor-covenant.org). By participating, you are expected to uphold this code.
+Everyone is welcome to contribute to Hubot. Contributing doesn’t just mean submitting pull requests—there are many different ways for you to get involved, including answering questions in [chat](https://hubot-slackin.herokuapp.com/), reporting or triaging [issues](https://github.com/github/hubot/issues), and participating in the [Hubot evolution process](https://github.com/hubotio/evolution).
 
+No matter how you want to get involved, we ask that you first learn what’s expected of anyone who participates in the project by reading the [Contributor Covenant Code of Conduct](http://contributor-covenant.org). By participating, you are expected to uphold this code.
 
 We love pull requests. Here's a quick guide:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,20 @@
 # Contributing
 
-Everyone is welcome to contribute to Hubot. Contributing doesn’t just mean submitting pull requests—there are many different ways for you to get involved, including answering questions in [chat](https://hubot-slackin.herokuapp.com/), reporting or triaging [issues](https://github.com/github/hubot/issues), and participating in the [Hubot evolution process](https://github.com/hubotio/evolution).
+Everyone is welcome to contribute to Hubot. Contributing doesn’t just mean submitting pull requests—there are many different ways for you to get involved, including answering questions in [chat](https://hubot-slackin.herokuapp.com/), reporting or triaging [issues](https://github.com/github/hubot/issues), and participating in the [Hubot Evolution](https://github.com/hubotio/evolution) process.
 
 No matter how you want to get involved, we ask that you first learn what’s expected of anyone who participates in the project by reading the [Contributor Covenant Code of Conduct](http://contributor-covenant.org). By participating, you are expected to uphold this code.
 
 We love pull requests. Here's a quick guide:
 
+1. If you're adding a new feature or changing user-facing APIs, check out the [Hubot Evolution](https://github.com/hubotio/evolution) process.
 1. Check for [existing issues](https://github.com/github/hubot/issues) for duplicates and confirm that it hasn't been fixed already in the [master branch](https://github.com/github/hubot/commits/master)
-2. Fork the repo, and clone it locally
-3. `npm link` to make your cloned repo available to npm
-4. Follow [Getting Started](docs/index.md) to generate a testbot
-5. `npm link hubot` in your newly created bot to use your hubot fork
-6. Create a new branch for your contribution
-7. Add [tests](test/) (run with `npm test`)
-8. Push to your fork and submit a pull request
+1. Fork the repo, and clone it locally
+1. `npm link` to make your cloned repo available to npm
+1. Follow [Getting Started](docs/index.md) to generate a testbot
+1. `npm link hubot` in your newly created bot to use your hubot fork
+1. Create a new branch for your contribution
+1. Add [tests](test/) (run with `npm test`)
+1. Push to your fork and submit a pull request
 
 At this point you're waiting on us. We like to at least comment on, if not
 accept, pull requests within a few days. We may suggest some changes or improvements or alternatives.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ This roadmap represents some of priorities for us over the next couple months. I
 - [x] Choose a chat platform for maintainers and contributors, and post notices in various existing places (#hubot on freenode, github/hubot on Gitter). Slack is the obvious choice here. [Join us on Slack](https://hubot-slackin.herokuapp.com/).
 - [x] Add a code of conduct based on http://contributor-covenant.org/ and processes to enforce it in all official spaces. ([#1334](https://github.com/github/hubot/pull/1334))
 - [ ] Publish weekly community updates (blog, newsletter, etc) which highlight recent and upcoming changes, give shoutouts to contributors / maintainers, and maybe mention interesting uses of Hubot
-- [x] Create Hubot Evolution—inspired by [Swift Evolution](https://github.com/apple/swift-evolution)—for proposing user-visible enhancements. This roadmap will be moved there and all future proposals will follow the process laid out in that repository. ([hubotio/evolution#1](https://github.com/hubotio/evolution/pull/1))
+- [x] Create Hubot Evolution—inspired by [Swift Evolution](https://github.com/apple/swift-evolution)—for proposing user-visible enhancements. ([hubotio/evolution#1](https://github.com/hubotio/evolution/pull/1))
 
 ## 3. Modernize the project
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,17 +21,17 @@ This roadmap represents some of priorities for us over the next couple months. I
 - [x] Choose a chat platform for maintainers and contributors, and post notices in various existing places (#hubot on freenode, github/hubot on Gitter). Slack is the obvious choice here. [Join us on Slack](https://hubot-slackin.herokuapp.com/).
 - [x] Add a code of conduct based on http://contributor-covenant.org/ and processes to enforce it in all official spaces. ([#1334](https://github.com/github/hubot/pull/1334))
 - [ ] Publish weekly community updates (blog, newsletter, etc) which highlight recent and upcoming changes, give shoutouts to contributors / maintainers, and maybe mention interesting uses of Hubot
-- [ ] Create Hubot Evolution—inspired by [Swift Evolution](https://github.com/apple/swift-evolution)—for proposing user-visible enhancements. This roadmap will be moved there and all future proposals will follow the process laid out in that repository. ([hubotio/evolution#1](https://github.com/hubotio/evolution/pull/1))
+- [x] Create Hubot Evolution—inspired by [Swift Evolution](https://github.com/apple/swift-evolution)—for proposing user-visible enhancements. This roadmap will be moved there and all future proposals will follow the process laid out in that repository. ([hubotio/evolution#1](https://github.com/hubotio/evolution/pull/1))
 
 ## 3. Modernize the project
 
-Each of these proposals will go through the “Hubot Evolution” process.
+Each of these proposals will go through the [Hubot Evolution](https://github.com/hubotio/evolution) process.
 
-- [ ] Translate from CoffeeScript to JavaScript and update to modern versions of Node.js and NPM (or Yarn)
-- [ ] Revisit new bot generator (yeoman has a ton of dependencies, some of which can be error prone on windows)
-- [ ] Support for running multiple adapters and archetypes (chat, deployment, CI, github, etc)
-- [ ] Merge with [@probot](https://github.com/probot) and build out first class GitHub integration.
-- [ ] Introduce "Commands”, an explicit interface for registering commands (like Slack’s slash commands) as an alternative to regular expressions
-- [ ] Publish a ChatOps RPC spec and implement support for Hubot acting as both a client and a server.
-- [ ] Support rich messages and interactions on platforms that support it
-- [ ] Publish a public script directory backed by NPM
+- Translate from CoffeeScript to JavaScript and update to modern versions of Node.js and NPM (or Yarn)
+- Revisit new bot generator (yeoman has a ton of dependencies, some of which can be error prone on windows)
+- Support for running multiple adapters and archetypes (chat, deployment, CI, github, etc)
+- Merge with [@probot](https://github.com/probot) and build out first class GitHub integration.
+- Introduce "Commands”, an explicit interface for registering commands (like Slack’s slash commands) as an alternative to regular expressions
+- Publish a ChatOps RPC spec and implement support for Hubot acting as both a client and a server.
+- Support rich messages and interactions on platforms that support it
+- Publish a public script directory backed by NPM


### PR DESCRIPTION
Going forward, all discussions about new features or changes to APIs will happen on the [Hubot evolution](https://github.com/hubotio/evolution) repo. Over the next week or so, we'll likely be closing a lot of the issues and PRs in this repository and pointing people toward the evolution repository as the place to discuss changes.

There will likely be some growing pains as we adjust to this new process, so feedback is always welcome!

cc https://github.com/hubotio/evolution/pull/1