### PR TITLE
move MockAdapter into hubot repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "scoped-http-client": "0.11.0"
   },
   "devDependencies": {
-    "hubot-mock-adapter": "^1.0.0",
     "coffee-errors": "0.8.6",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",

--- a/test/adapter_test.coffee
+++ b/test/adapter_test.coffee
@@ -4,7 +4,7 @@ chai.use require 'sinon-chai'
 
 expect = chai.expect
 
-Adapter = require '../src/adapter.coffee'
+Adapter = require '../src/adapter'
 
 describe 'Adapter', ->
   beforeEach ->

--- a/test/brain_test.coffee
+++ b/test/brain_test.coffee
@@ -6,8 +6,8 @@ chai.use require 'sinon-chai'
 { expect } = chai
 
 # Hubot classes
-Brain = require '../src/brain.coffee'
-User = require '../src/user.coffee'
+Brain = require '../src/brain'
+User = require '../src/user'
 
 describe 'Brain', ->
   beforeEach ->

--- a/test/fixtures/mock-adapter.coffee
+++ b/test/fixtures/mock-adapter.coffee
@@ -1,0 +1,12 @@
+Adapter = require('../..').Adapter
+
+class MockAdapter extends Adapter
+  send: (envelope, strings...) -> @emit('send', envelope, strings)
+  reply: (envelope, strings...) -> @emit('reply', envelope, strings)
+  topic: (envelope, strings...) -> @emit('topic', envelope, strings)
+  play: (envelope, strings...) -> @emit('play', envelope, strings)
+
+  run: -> @emit('connected')
+  close: -> @emit('closed')
+
+module.exports.use = (robot) -> return new MockAdapter(robot)

--- a/test/listener_test.coffee
+++ b/test/listener_test.coffee
@@ -8,8 +8,8 @@ chai.use require 'sinon-chai'
 # Hubot classes
 { CatchAllMessage, EnterMessage, TextMessage } = require '../src/message'
 { Listener, TextListener } = require '../src/listener'
-Response = require '../src/response.coffee'
-User = require '../src/user.coffee'
+Response = require '../src/response'
+User = require '../src/user'
 
 describe 'Listener', ->
   beforeEach ->

--- a/test/message_test.coffee
+++ b/test/message_test.coffee
@@ -6,7 +6,7 @@ chai.use require 'sinon-chai'
 { expect } = chai
 
 # Hubot classes
-User = require '../src/user.coffee'
+User = require '../src/user'
 { CatchAllMessage, EnterMessage, Message, TextMessage } = require '../src/message'
 
 describe 'Message', ->

--- a/test/middleware_test.coffee
+++ b/test/middleware_test.coffee
@@ -5,27 +5,15 @@ chai.use require 'sinon-chai'
 
 { expect } = chai
 
-mockery = require 'mockery'
-
 # Hubot classes
-Robot = require '../src/robot.coffee'
+Robot = require '../src/robot'
 { CatchAllMessage, EnterMessage, TextMessage } = require '../src/message'
 Adapter = require '../src/adapter'
 Response = require '../src/response'
 Middleware = require '../src/middleware'
 
-# Preload the Hubot mock adapter but substitute in the latest version of Adapter
-mockery.enable()
-mockery.registerAllowable 'hubot-mock-adapter'
-mockery.registerAllowable 'lodash' # hubot-mock-adapter uses lodash
-# Force hubot-mock-adapter to use the latest version of Adapter
-mockery.registerMock 'hubot/src/adapter', Adapter
-# Load the mock adapter into the cache
-require 'hubot-mock-adapter'
-# We're done with mockery
-mockery.deregisterMock 'hubot/src/adapter'
-mockery.disable()
-
+# mock `hubot-mock-adapter` module from fixture
+mockery = require 'mockery'
 
 describe 'Middleware', ->
   describe 'Unit Tests', ->
@@ -311,6 +299,11 @@ describe 'Middleware', ->
   # tested for.
   describe 'Public Middleware APIs', ->
     beforeEach ->
+      mockery.enable({
+        warnOnReplace: false,
+        warnOnUnregistered: false
+      })
+      mockery.registerMock 'hubot-mock-adapter', require('./fixtures/mock-adapter')
       @robot = new Robot null, 'mock-adapter', yes, 'TestHubot'
       @robot.run
 
@@ -334,6 +327,7 @@ describe 'Middleware', ->
       @testListener = @robot.listeners[0]
 
     afterEach ->
+      mockery.disable()
       @robot.shutdown()
 
     describe 'listener middleware context', ->

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -5,30 +5,23 @@ chai.use require 'sinon-chai'
 
 { expect } = chai
 
-mockery = require 'mockery'
-
 # Hubot classes
-Robot = require '../src/robot.coffee'
+Robot = require '../src/robot'
 { CatchAllMessage, EnterMessage, LeaveMessage, TextMessage, TopicMessage } = require '../src/message'
 Adapter = require '../src/adapter'
 
 ScopedHttpClient = require 'scoped-http-client'
 
-# Preload the Hubot mock adapter but substitute in the latest version of Adapter
-mockery.enable()
-mockery.registerAllowable 'hubot-mock-adapter'
-mockery.registerAllowable 'lodash' # hubot-mock-adapter uses lodash
-# Force hubot-mock-adapter to use the latest version of Adapter
-mockery.registerMock 'hubot/src/adapter', Adapter
-# Load the mock adapter into the cache
-require 'hubot-mock-adapter'
-# We're done with mockery
-mockery.deregisterMock 'hubot/src/adapter'
-mockery.disable()
-
+# mock `hubot-mock-adapter` module from fixture
+mockery = require 'mockery'
 
 describe 'Robot', ->
   beforeEach ->
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    })
+    mockery.registerMock 'hubot-mock-adapter', require('./fixtures/mock-adapter')
     @robot = new Robot null, 'mock-adapter', yes, 'TestHubot'
     @robot.alias = 'Hubot'
     @robot.run
@@ -46,7 +39,8 @@ describe 'Robot', ->
     }
 
   afterEach ->
-   @robot.shutdown()
+    mockery.disable()
+    @robot.shutdown()
 
   describe 'Unit Tests', ->
     describe '#http', ->

--- a/test/user_test.coffee
+++ b/test/user_test.coffee
@@ -1,5 +1,5 @@
 {expect} = require 'chai'
-User = require '../src/user.coffee'
+User = require '../src/user'
 
 describe 'User', ->
   describe 'new', ->


### PR DESCRIPTION
This is in preparation of #1347. Having the declaration of `MockAdapter` inside the Hubot repository makes sense anyway, it is fairly simple and we depend on it in our tests, so we should have full control. The main problem is that [`hubot-mock-adapter` does `require('hubot/src/adapter')`](https://github.com/blalor/hubot-mock-adapter/blob/5cb366c9150693624050bc2b04e39c83470de5e8/index.js#L23) which I don’t think is officially supported, it should be `require('hubot').Adapter` instead. 

If we want to keep a `hubot-mock-adapter` we should bring it up to date (e.g. it refers `src/scripts` in the README.md which doesn’t exist) and move it to the hubotio GitHub organization.

In #1347 we want to convert the tests independent of the source files, and the changes in this PR became necessary for the tests to still pass after converting all `/src/*` files to JavaScript.